### PR TITLE
fix: ファイル監視の多重通知を抑制しダウンロード中の更新漏れを防止

### DIFF
--- a/tests/DcsTranslationTool.Presentation.Wpf.Tests/Features/Download/DownloadViewModelTests.cs
+++ b/tests/DcsTranslationTool.Presentation.Wpf.Tests/Features/Download/DownloadViewModelTests.cs
@@ -90,6 +90,9 @@ public sealed class DownloadViewModelTests : IDisposable {
             .Returns( appSettings );
 
         var fileEntryServiceMock = new Mock<IFileEntryService>();
+        fileEntryServiceMock
+            .Setup( service => service.GetEntriesAsync() )
+            .ReturnsAsync( Result.Ok<IReadOnlyList<FileEntry>>( Array.Empty<FileEntry>() ) );
         var loggingServiceMock = new Mock<ILoggingService>();
         var snackbarMessages = new List<string>();
         var snackbarMessageQueueMock = new Mock<ISnackbarMessageQueue>();
@@ -234,6 +237,9 @@ public sealed class DownloadViewModelTests : IDisposable {
             .Returns( appSettings );
 
         var fileEntryServiceMock = new Mock<IFileEntryService>();
+        fileEntryServiceMock
+            .Setup( service => service.GetEntriesAsync() )
+            .ReturnsAsync( Result.Ok<IReadOnlyList<FileEntry>>( Array.Empty<FileEntry>() ) );
         var loggingServiceMock = new Mock<ILoggingService>();
         var snackbarMessages = new List<string>();
         var snackbarMessageQueueMock = new Mock<ISnackbarMessageQueue>();


### PR DESCRIPTION
## 📌 概要

ファイル監視の多重通知を抑制しダウンロード中の更新漏れを防止

## 🛠 変更内容

ファイル監視の多重通知を抑制しダウンロード中の更新漏れを防止

## 留意点

<!-- このPRを使用するうえで注意すべきことをリストアップしてください。 -->
<!-- 必要がなければ N/A としてください -->
N/A
