### PR TITLE
ci(dependabot): align PR title prefixes with Conventional Commits

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,9 @@ updates:
   labels:
     - "dependencies"
     - "CI / GitHub Actions"
+  commit-message:
+    prefix: "chore"
+    include: "scope"
 
 # ─────────────────────────────────────────────────────────
 # 2) NuGet パッケージを監視
@@ -37,3 +40,8 @@ updates:
   labels:
     - "dependencies"
     - "Dependencies / NuGet"
+  rebase-strategy: "auto"
+  commit-message:
+    prefix: "fix"
+    prefix-development: "chore"
+    include: "scope"


### PR DESCRIPTION
## 📌 概要

<!-- このPRの目的・背景を簡潔に書いてください -->
Dependabot が作成する PR タイトルの prefix を見直し、Conventional Commits の運用に寄せました。

## 🛠 変更内容

<!-- このPRで加えた変更をリストアップしてください -->
- npm 依存更新の PR タイトル prefix を分離
  - dependencies → `fix`
  - devDependencies → `chore`
- GitHub Actions 更新の PR タイトル prefix を `chore(ci)` に統一
- `include: scope` を有効化し、更新対象（package / group）がタイトルから判別できるように変更

## 留意点

<!-- このPRを使用するうえで注意すべきことをリストアップしてください。 -->
<!-- 必要がなければ N/A としてください -->
N/A

Closes #34 