### PR TITLE
refactor(workflow): 進捗通知をリアルタイム配信に統一しキャンセル制御を安定化

### DIFF
--- a/src/DcsTranslationTool.Presentation.Wpf/Bootstrapper.cs
+++ b/src/DcsTranslationTool.Presentation.Wpf/Bootstrapper.cs
@@ -45,6 +45,8 @@ public class Bootstrapper : BootstrapperBase {
         container.Singleton<IDialogService, DialogService>();
         container.Singleton<IDialogProvider, DialogProvider>();
         container.Singleton<IDispatcherService, DispatcherService>();
+        container.Singleton<IDownloadWorkflowService, DownloadWorkflowService>();
+        container.Singleton<IApplyWorkflowService, ApplyWorkflowService>();
         container.Singleton<ISnackbarService, SnackbarService>();
 
         // ViewModels

--- a/src/DcsTranslationTool.Presentation.Wpf/Services/Abstractions/ApplyWorkflowResult.cs
+++ b/src/DcsTranslationTool.Presentation.Wpf/Services/Abstractions/ApplyWorkflowResult.cs
@@ -1,0 +1,11 @@
+namespace DcsTranslationTool.Presentation.Wpf.Services.Abstractions;
+
+/// <summary>
+/// 適用ワークフロー実行結果を表す。
+/// </summary>
+/// <param name="IsSuccess">処理が成功したかどうか。</param>
+/// <param name="Events">発生イベント一覧。</param>
+public sealed record ApplyWorkflowResult(
+    bool IsSuccess,
+    IReadOnlyList<WorkflowEvent> Events
+);

--- a/src/DcsTranslationTool.Presentation.Wpf/Services/Abstractions/DownloadWorkflowResult.cs
+++ b/src/DcsTranslationTool.Presentation.Wpf/Services/Abstractions/DownloadWorkflowResult.cs
@@ -1,0 +1,11 @@
+namespace DcsTranslationTool.Presentation.Wpf.Services.Abstractions;
+
+/// <summary>
+/// ダウンロードワークフロー実行結果を表す。
+/// </summary>
+/// <param name="IsSuccess">処理が成功したかどうか。</param>
+/// <param name="Events">発生イベント一覧。</param>
+public sealed record DownloadWorkflowResult(
+    bool IsSuccess,
+    IReadOnlyList<WorkflowEvent> Events
+);

--- a/src/DcsTranslationTool.Presentation.Wpf/Services/Abstractions/IApplyWorkflowService.cs
+++ b/src/DcsTranslationTool.Presentation.Wpf/Services/Abstractions/IApplyWorkflowService.cs
@@ -1,0 +1,29 @@
+using DcsTranslationTool.Presentation.Wpf.UI.Interfaces;
+
+namespace DcsTranslationTool.Presentation.Wpf.Services.Abstractions;
+
+/// <summary>
+/// 適用ワークフローを提供するサービス契約を表す。
+/// </summary>
+public interface IApplyWorkflowService {
+    /// <summary>
+    /// 翻訳ファイルを対象ディレクトリへ適用する。
+    /// </summary>
+    /// <param name="targetEntries">適用対象エントリ。</param>
+    /// <param name="rootFullPath">適用先ルート絶対パス。</param>
+    /// <param name="rootWithSeparator">区切り文字付き適用先ルート。</param>
+    /// <param name="translateFullPath">翻訳ルート絶対パス。</param>
+    /// <param name="translateRootWithSeparator">区切り文字付き翻訳ルート。</param>
+    /// <param name="cancellationToken">キャンセルトークン。</param>
+    /// <param name="progress">進捗イベント通知先。</param>
+    /// <returns>実行結果。</returns>
+    Task<ApplyWorkflowResult> ApplyAsync(
+        IReadOnlyList<IFileEntryViewModel> targetEntries,
+        string rootFullPath,
+        string rootWithSeparator,
+        string translateFullPath,
+        string translateRootWithSeparator,
+        CancellationToken cancellationToken = default,
+        IProgress<WorkflowEvent>? progress = null
+    );
+}

--- a/src/DcsTranslationTool.Presentation.Wpf/Services/Abstractions/IDownloadWorkflowService.cs
+++ b/src/DcsTranslationTool.Presentation.Wpf/Services/Abstractions/IDownloadWorkflowService.cs
@@ -1,0 +1,23 @@
+using DcsTranslationTool.Application.Contracts;
+
+namespace DcsTranslationTool.Presentation.Wpf.Services.Abstractions;
+
+/// <summary>
+/// ダウンロードワークフローを提供するサービス契約を表す。
+/// </summary>
+public interface IDownloadWorkflowService {
+    /// <summary>
+    /// 指定されたダウンロード対象を保存する。
+    /// </summary>
+    /// <param name="items">ダウンロード対象一覧。</param>
+    /// <param name="saveRootPath">保存先ルートパス。</param>
+    /// <param name="cancellationToken">キャンセルトークン。</param>
+    /// <param name="progress">進捗イベント通知先。</param>
+    /// <returns>実行結果。</returns>
+    Task<DownloadWorkflowResult> DownloadFilesAsync(
+        IReadOnlyList<ApiDownloadFilePathsItem> items,
+        string saveRootPath,
+        CancellationToken cancellationToken = default,
+        IProgress<WorkflowEvent>? progress = null
+    );
+}

--- a/src/DcsTranslationTool.Presentation.Wpf/Services/Abstractions/WorkflowEvents.cs
+++ b/src/DcsTranslationTool.Presentation.Wpf/Services/Abstractions/WorkflowEvents.cs
@@ -1,0 +1,27 @@
+namespace DcsTranslationTool.Presentation.Wpf.Services.Abstractions;
+
+/// <summary>
+/// ワークフロー処理が通知するイベント種別を表す。
+/// </summary>
+public enum WorkflowEventKind {
+    /// <summary>メッセージ通知を表す。</summary>
+    Notification,
+
+    /// <summary>ダウンロード進捗更新を表す。</summary>
+    DownloadProgress,
+
+    /// <summary>適用進捗更新を表す。</summary>
+    ApplyProgress
+}
+
+/// <summary>
+/// ワークフロー処理イベントを表す。
+/// </summary>
+/// <param name="Kind">イベント種別。</param>
+/// <param name="Message">通知メッセージ。</param>
+/// <param name="Progress">進捗率。</param>
+public sealed record WorkflowEvent(
+    WorkflowEventKind Kind,
+    string? Message = null,
+    double? Progress = null
+);

--- a/src/DcsTranslationTool.Presentation.Wpf/Services/ApplyWorkflowService.cs
+++ b/src/DcsTranslationTool.Presentation.Wpf/Services/ApplyWorkflowService.cs
@@ -1,0 +1,237 @@
+using System.IO;
+
+using DcsTranslationTool.Application.Contracts;
+using DcsTranslationTool.Application.Interfaces;
+using DcsTranslationTool.Application.Results;
+using DcsTranslationTool.Domain.Models;
+using DcsTranslationTool.Presentation.Wpf.Services.Abstractions;
+using DcsTranslationTool.Presentation.Wpf.UI.Interfaces;
+
+namespace DcsTranslationTool.Presentation.Wpf.Services;
+
+/// <summary>
+/// 適用ワークフローを提供する。
+/// </summary>
+public sealed class ApplyWorkflowService(
+    IApiService apiService,
+    IDownloadWorkflowService downloadWorkflowService,
+    ILoggingService logger,
+    IZipService zipService
+) : IApplyWorkflowService {
+    private static readonly string[] ZipLikeExtensions = [".miz", ".trk"];
+
+    /// <inheritdoc/>
+    public async Task<ApplyWorkflowResult> ApplyAsync(
+        IReadOnlyList<IFileEntryViewModel> targetEntries,
+        string rootFullPath,
+        string rootWithSeparator,
+        string translateFullPath,
+        string translateRootWithSeparator,
+        CancellationToken cancellationToken = default,
+        IProgress<WorkflowEvent>? progress = null
+    ) {
+        var events = new List<WorkflowEvent>();
+        var repoOnlyEntries = targetEntries
+            .Where( entry => entry.ChangeType == FileChangeType.RepoOnly )
+            .ToList();
+
+        if(repoOnlyEntries.Count > 0) {
+            var pathResult = await apiService.DownloadFilePathsAsync(
+                new ApiDownloadFilePathsRequest( targetEntries.Select( e => e.Path ).ToList(), null ),
+                cancellationToken
+            );
+
+            if(pathResult.IsFailed) {
+                var reason = pathResult.Errors.Count > 0 ? pathResult.Errors[0].Message : null;
+                logger.Error( $"ダウンロードURLの取得に失敗した。Reason={reason}" );
+                events.Add( new WorkflowEvent(
+                    WorkflowEventKind.Notification,
+                    ResultNotificationPolicy.GetDownloadPathFailureMessage( pathResult.GetFirstErrorKind() ) ) );
+                return new ApplyWorkflowResult( false, events );
+            }
+
+            var downloadItems = pathResult.Value.Items.ToArray();
+            if(downloadItems.Length == 0) {
+                events.Add( new WorkflowEvent( WorkflowEventKind.Notification, "対象ファイルは最新です" ) );
+            }
+            else {
+                var downloadResult = await downloadWorkflowService.DownloadFilesAsync( downloadItems, translateFullPath, cancellationToken, progress );
+                events.AddRange( downloadResult.Events );
+                if(!downloadResult.IsSuccess) {
+                    return new ApplyWorkflowResult( false, events );
+                }
+            }
+
+            foreach(var repoEntry in repoOnlyEntries) {
+                if(!TryResolvePathWithinRoot( translateFullPath, translateRootWithSeparator, repoEntry.Path, out var repoPath ) || !File.Exists( repoPath )) {
+                    logger.Warn( $"取得後もファイルが存在しない。Path={repoEntry.Path}, Resolved={repoPath}" );
+                    events.Add( new WorkflowEvent( WorkflowEventKind.Notification, $"取得失敗: {repoEntry.Path}" ) );
+                    return new ApplyWorkflowResult( false, events );
+                }
+            }
+        }
+
+        var success = 0;
+        var failed = 0;
+
+        if(targetEntries.Count == 0) {
+            var completedEvent = new WorkflowEvent( WorkflowEventKind.ApplyProgress, Progress: 100 );
+            events.Add( completedEvent );
+            progress?.Report( completedEvent );
+            events.Add( new WorkflowEvent( WorkflowEventKind.Notification, "適用完了 成功:0 件 失敗:0 件" ) );
+            return new ApplyWorkflowResult( true, events );
+        }
+
+        var progressed = 0;
+        foreach(var entry in targetEntries) {
+            cancellationToken.ThrowIfCancellationRequested();
+            try {
+                string? message = null;
+                if(!TryResolvePathWithinRoot( translateFullPath, translateRootWithSeparator, entry.Path, out var sourceFilePath )) {
+                    failed++;
+                    message = $"不正な翻訳ファイル: {entry.Path}";
+                }
+                else if(!File.Exists( sourceFilePath )) {
+                    failed++;
+                    message = $"翻訳ファイルが見つかりません: {entry.Path}";
+                }
+                else {
+                    var parts = entry.Path.Split( '/', StringSplitOptions.RemoveEmptyEntries );
+                    var archiveIndex = Array.FindIndex( parts, IsZipLikeEntrySegment );
+                    var rootSkipCount = GetRootSegmentSkipCount( parts );
+
+                    if(archiveIndex == -1) {
+                        var relativeSegments = parts.Skip( rootSkipCount ).ToArray();
+                        if(relativeSegments.Length == 0) {
+                            failed++;
+                            message = $"不正なパス構造: {entry.Path}";
+                        }
+                        else {
+                            var relativePath = string.Join( '/', relativeSegments );
+                            if(!TryResolvePathWithinRoot( rootFullPath, rootWithSeparator, relativePath, out var destinationPath )) {
+                                failed++;
+                                message = $"不正な適用先: {entry.Path}";
+                            }
+                            else {
+                                try {
+                                    var directoryName = Path.GetDirectoryName( destinationPath );
+                                    if(!string.IsNullOrEmpty( directoryName )) {
+                                        Directory.CreateDirectory( directoryName );
+                                    }
+                                    File.Copy( sourceFilePath, destinationPath, overwrite: true );
+                                    success++;
+                                }
+                                catch(Exception ex) {
+                                    failed++;
+                                    message = $"適用失敗: {entry.Path}";
+                                    logger.Error( $"ファイルの適用に失敗した。Path={destinationPath}", ex );
+                                }
+                            }
+                        }
+                    }
+                    else {
+                        var archiveSegments = parts.Take( archiveIndex + 1 ).Skip( rootSkipCount ).ToArray();
+                        if(archiveSegments.Length == 0) {
+                            failed++;
+                            message = $"不正なパス構造: {entry.Path}";
+                        }
+                        else {
+                            var archiveRelativePath = string.Join( '/', archiveSegments );
+                            if(!TryResolvePathWithinRoot( rootFullPath, rootWithSeparator, archiveRelativePath, out var archivePath )) {
+                                failed++;
+                                message = $"不正な適用先: {entry.Path}";
+                            }
+                            else if(!File.Exists( archivePath )) {
+                                failed++;
+                                message = $"圧縮ファイルが存在しません: {entry.Path}";
+                            }
+                            else {
+                                var entryPathSegments = parts.Skip( archiveIndex + 1 ).ToArray();
+                                if(entryPathSegments.Length == 0) {
+                                    failed++;
+                                    message = $"圧縮ファイル内パスが不正です: {entry.Path}";
+                                }
+                                else {
+                                    var entryPath = string.Join( '/', entryPathSegments );
+                                    var addResult = zipService.AddEntry( archivePath, entryPath, sourceFilePath );
+                                    if(addResult.IsFailed) {
+                                        failed++;
+                                        message = $"適用失敗: {entry.Path}";
+                                    }
+                                    else {
+                                        success++;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                if(message is not null) {
+                    events.Add( new WorkflowEvent( WorkflowEventKind.Notification, message ) );
+                }
+            }
+            catch(Exception ex) {
+                failed++;
+                logger.Error( $"適用処理で例外が発生した。Path={entry.Path}", ex );
+                events.Add( new WorkflowEvent( WorkflowEventKind.Notification, $"適用失敗: {entry.Path}" ) );
+            }
+
+            progressed++;
+            var progressEvent = new WorkflowEvent(
+                WorkflowEventKind.ApplyProgress,
+                Progress: Math.Min( 100, (double)progressed / targetEntries.Count * 100 ) );
+            events.Add( progressEvent );
+            progress?.Report( progressEvent );
+        }
+
+        var completed = new WorkflowEvent( WorkflowEventKind.ApplyProgress, Progress: 100 );
+        events.Add( completed );
+        progress?.Report( completed );
+        events.Add( new WorkflowEvent( WorkflowEventKind.Notification, $"適用完了 成功:{success} 件 失敗:{failed} 件" ) );
+        logger.Info( $"適用処理が完了した。成功={success}, 失敗={failed}" );
+        return new ApplyWorkflowResult( true, events );
+    }
+
+    /// <summary>ルートディレクトリ配下に収まるようにパスを解決する。</summary>
+    private static bool TryResolvePathWithinRoot( string rootFullPath, string rootWithSeparator, string relativePath, out string resolvedPath ) {
+        resolvedPath = string.Empty;
+        if(string.IsNullOrWhiteSpace( relativePath )) {
+            return false;
+        }
+
+        var candidate = Path.GetFullPath(
+            Path.Combine( rootFullPath, relativePath.Replace( '/', Path.DirectorySeparatorChar ) )
+        );
+
+        if(!candidate.StartsWith( rootWithSeparator, StringComparison.OrdinalIgnoreCase )) {
+            return false;
+        }
+
+        resolvedPath = candidate;
+        return true;
+    }
+
+    /// <summary>パス先頭のルートセグメントを何個スキップするかを取得する。</summary>
+    private static int GetRootSegmentSkipCount( string[] segments ) {
+        if(segments.Length == 0) {
+            return 0;
+        }
+
+        if(string.Equals( segments[0], "DCSWorld", StringComparison.OrdinalIgnoreCase ) &&
+           segments.Length >= 3 &&
+           string.Equals( segments[1], "Mods", StringComparison.OrdinalIgnoreCase )) {
+            return 3;
+        }
+
+        if(string.Equals( segments[0], "UserMissions", StringComparison.OrdinalIgnoreCase )) {
+            return 1;
+        }
+
+        return 0;
+    }
+
+    /// <summary>ZIPとして扱う拡張子を含むかを判定する。</summary>
+    private static bool IsZipLikeEntrySegment( string segment ) =>
+        ZipLikeExtensions.Any( ext => segment.EndsWith( ext, StringComparison.OrdinalIgnoreCase ) );
+}

--- a/src/DcsTranslationTool.Presentation.Wpf/Services/DownloadWorkflowService.cs
+++ b/src/DcsTranslationTool.Presentation.Wpf/Services/DownloadWorkflowService.cs
@@ -1,0 +1,172 @@
+using System.Collections.Concurrent;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Sockets;
+
+using DcsTranslationTool.Application.Contracts;
+using DcsTranslationTool.Presentation.Wpf.Services.Abstractions;
+
+namespace DcsTranslationTool.Presentation.Wpf.Services;
+
+/// <summary>
+/// ダウンロード処理を提供する。
+/// </summary>
+public sealed class DownloadWorkflowService(
+    ILoggingService logger
+) : IDownloadWorkflowService {
+    private static readonly ConcurrentDictionary<string, IPAddress> LastSuccessfulAddressCache = new();
+
+    /// <inheritdoc/>
+    public async Task<DownloadWorkflowResult> DownloadFilesAsync(
+        IReadOnlyList<ApiDownloadFilePathsItem> items,
+        string saveRootPath,
+        CancellationToken cancellationToken = default,
+        IProgress<WorkflowEvent>? progress = null
+    ) {
+        if(items.Count == 0) {
+            return new DownloadWorkflowResult( true, [] );
+        }
+
+        var successCount = 0;
+        var failureCount = 0;
+        var progressed = 0;
+        var progressEvents = new ConcurrentQueue<(int Sequence, WorkflowEvent Event)>();
+
+        var maxConcurrency = Math.Clamp( Environment.ProcessorCount, 2, 6 );
+        using var semaphore = new SemaphoreSlim( maxConcurrency );
+        using var httpClient = CreateHttpClient();
+        List<Task> tasks = [];
+        var isCancellationRequested = false;
+
+        foreach(var item in items) {
+            try {
+                await semaphore.WaitAsync( cancellationToken );
+            }
+            catch(OperationCanceledException) when(cancellationToken.IsCancellationRequested) {
+                isCancellationRequested = true;
+                break;
+            }
+
+            tasks.Add( Task.Run( async () => {
+                var canceled = false;
+                try {
+                    var filePath = Path.Combine( saveRootPath, item.Path );
+                    await DownloadFileAsync( httpClient, item.Url, filePath, cancellationToken );
+                    Interlocked.Increment( ref successCount );
+                }
+                catch(OperationCanceledException) when(cancellationToken.IsCancellationRequested) {
+                    canceled = true;
+                    throw;
+                }
+                catch(Exception ex) {
+                    Interlocked.Increment( ref failureCount );
+                    logger.Error( $"ファイルのダウンロードに失敗した。Path={item.Path}", ex );
+                }
+                finally {
+                    if(!canceled) {
+                        var current = Interlocked.Increment( ref progressed );
+                        var progressEvent = new WorkflowEvent(
+                            WorkflowEventKind.DownloadProgress,
+                            Progress: Math.Min( 100, (double)current / items.Count * 100 ) );
+                        progressEvents.Enqueue( (current, progressEvent) );
+                        progress?.Report( progressEvent );
+                    }
+                    semaphore.Release();
+                }
+            } ) );
+        }
+
+        try {
+            await Task.WhenAll( tasks );
+        }
+        catch(OperationCanceledException) when(cancellationToken.IsCancellationRequested) {
+            isCancellationRequested = true;
+        }
+
+        if(isCancellationRequested) {
+            cancellationToken.ThrowIfCancellationRequested();
+        }
+
+        logger.Info( $"ファイルのダウンロードが完了した。成功={successCount}/{items.Count} 件, 失敗={failureCount}/{items.Count} 件" );
+
+        var events = progressEvents
+            .OrderBy( e => e.Sequence )
+            .Select( e => e.Event )
+            .ToList();
+
+        if(failureCount > 0) {
+            events.Add( new WorkflowEvent( WorkflowEventKind.Notification, $"一部のファイルの保存に失敗しました ({failureCount}/{items.Count})" ) );
+        }
+
+        return new DownloadWorkflowResult( failureCount == 0, events );
+    }
+
+    /// <summary>
+    /// 単一ファイルを保存する。
+    /// </summary>
+    private async Task DownloadFileAsync( HttpClient httpClient, string url, string filePath, CancellationToken cancellationToken ) {
+        logger.Info( $"ファイルをダウンロードする。Url={url}, FilePath={filePath}" );
+        var bytes = await httpClient.GetByteArrayAsync( url, cancellationToken );
+        var directoryName = Path.GetDirectoryName( filePath );
+        if(!string.IsNullOrEmpty( directoryName ) && !Directory.Exists( directoryName )) {
+            Directory.CreateDirectory( directoryName );
+        }
+
+        await File.WriteAllBytesAsync( filePath, bytes, cancellationToken );
+    }
+
+    /// <summary>
+    /// 環境差異を吸収する HttpClient を生成する。
+    /// </summary>
+    private static HttpClient CreateHttpClient() {
+        var handler = new SocketsHttpHandler
+        {
+            ConnectTimeout = TimeSpan.FromSeconds( 3 ),
+            ConnectCallback = async ( context, token ) => {
+                var host = context.DnsEndPoint!.Host;
+                var port = context.DnsEndPoint.Port;
+                var hostKey = host.ToLowerInvariant();
+
+                IPAddress[] v4 = [];
+                IPAddress[] v6 = [];
+                try {
+                    v4 = await Dns.GetHostAddressesAsync( host, AddressFamily.InterNetwork, token );
+                }
+                catch {
+                    // IPv4 解決不可は許容する。
+                }
+                try {
+                    v6 = await Dns.GetHostAddressesAsync( host, AddressFamily.InterNetworkV6, token );
+                }
+                catch {
+                    // IPv6 解決不可は許容する。
+                }
+
+                var candidates = new List<IPAddress>( v4.Length + v6.Length + 1 );
+                if(LastSuccessfulAddressCache.TryGetValue( hostKey, out var cached )) {
+                    candidates.Add( cached );
+                }
+                candidates.AddRange( v4 );
+                candidates.AddRange( v6 );
+
+                foreach(var addr in candidates.Distinct()) {
+                    var socket = new Socket( addr.AddressFamily, SocketType.Stream, ProtocolType.Tcp ) { NoDelay = true };
+                    try {
+                        await socket.ConnectAsync( addr, port, token );
+                        LastSuccessfulAddressCache[hostKey] = addr;
+                        return new NetworkStream( socket, ownsSocket: true );
+                    }
+                    catch {
+                        socket.Dispose();
+                    }
+                }
+
+                LastSuccessfulAddressCache.TryRemove( hostKey, out _ );
+                throw new SocketException( (int)SocketError.HostUnreachable );
+            }
+        };
+
+        return new HttpClient( handler, disposeHandler: true );
+    }
+}

--- a/tests/DcsTranslationTool.Presentation.Wpf.Tests/BootstrapperContainerTests.cs
+++ b/tests/DcsTranslationTool.Presentation.Wpf.Tests/BootstrapperContainerTests.cs
@@ -87,6 +87,8 @@ public sealed class BootstrapperContainerTests {
 
             Container.Singleton<IDialogProvider, DialogProvider>();
             Container.Singleton<IDispatcherService, DispatcherService>();
+            Container.Singleton<IDownloadWorkflowService, DownloadWorkflowService>();
+            Container.Singleton<IApplyWorkflowService, ApplyWorkflowService>();
             Container.Singleton<ISnackbarService, SnackbarService>();
 
             var navigationServiceMock = new Mock<INavigationService>();
@@ -117,6 +119,8 @@ public sealed class BootstrapperContainerTests {
             Assert.IsType<ZipService>( Get<IZipService>() );
             Assert.IsType<DialogProvider>( Get<IDialogProvider>() );
             Assert.IsType<DispatcherService>( Get<IDispatcherService>() );
+            Assert.IsType<DownloadWorkflowService>( Get<IDownloadWorkflowService>() );
+            Assert.IsType<ApplyWorkflowService>( Get<IApplyWorkflowService>() );
             Assert.IsType<SnackbarService>( Get<ISnackbarService>() );
             Assert.IsType<WindowManager>( Get<IWindowManager>() );
             Assert.IsType<EventAggregator>( Get<IEventAggregator>() );

--- a/tests/DcsTranslationTool.Presentation.Wpf.Tests/Services/ApplyWorkflowServiceTests.cs
+++ b/tests/DcsTranslationTool.Presentation.Wpf.Tests/Services/ApplyWorkflowServiceTests.cs
@@ -1,0 +1,57 @@
+using DcsTranslationTool.Application.Contracts;
+using DcsTranslationTool.Application.Interfaces;
+using DcsTranslationTool.Application.Results;
+using DcsTranslationTool.Presentation.Wpf.Services;
+using DcsTranslationTool.Presentation.Wpf.Services.Abstractions;
+using DcsTranslationTool.Presentation.Wpf.UI.Enums;
+using DcsTranslationTool.Presentation.Wpf.ViewModels;
+using DcsTranslationTool.Shared.Models;
+
+using FluentResults;
+
+using Moq;
+
+namespace DcsTranslationTool.Presentation.Wpf.Tests.Services;
+
+public sealed class ApplyWorkflowServiceTests {
+    [Fact]
+    public async Task ApplyAsyncはURL取得失敗時に失敗結果を返す() {
+        var apiServiceMock = new Mock<IApiService>( MockBehavior.Strict );
+        var downloadWorkflowServiceMock = new Mock<IDownloadWorkflowService>( MockBehavior.Strict );
+        var loggerMock = new Mock<ILoggingService>();
+        var zipServiceMock = new Mock<IZipService>( MockBehavior.Strict );
+        var sut = new ApplyWorkflowService(
+            apiServiceMock.Object,
+            downloadWorkflowServiceMock.Object,
+            loggerMock.Object,
+            zipServiceMock.Object
+        );
+
+        const string repoPath = "DCSWorld/Mods/aircraft/A10C/L10N/RepoOnly.lua";
+        var entry = new FileEntryViewModel(
+            new RepoFileEntry( "RepoOnly.lua", repoPath, false, "repo" ),
+            ChangeTypeMode.Download,
+            loggerMock.Object
+        );
+
+        apiServiceMock
+            .Setup( service => service.DownloadFilePathsAsync(
+                It.Is<ApiDownloadFilePathsRequest>( request => request.Paths.Count == 1 && request.Paths[0] == repoPath ),
+                It.IsAny<CancellationToken>()
+            ) )
+            .ReturnsAsync( Result.Fail<ApiDownloadFilePathsResult>( ResultErrorFactory.External( "failed", "TEST" ) ) );
+
+        var result = await sut.ApplyAsync(
+            [entry],
+            "root",
+            "root\\",
+            "translate",
+            "translate\\",
+            TestContext.Current.CancellationToken
+        );
+
+        Assert.False( result.IsSuccess );
+        Assert.Contains( result.Events, e => e.Kind == WorkflowEventKind.Notification && e.Message == "ダウンロードURLの取得に失敗しました" );
+        apiServiceMock.VerifyAll();
+    }
+}

--- a/tests/DcsTranslationTool.Presentation.Wpf.Tests/Services/DownloadWorkflowServiceTests.cs
+++ b/tests/DcsTranslationTool.Presentation.Wpf.Tests/Services/DownloadWorkflowServiceTests.cs
@@ -1,0 +1,39 @@
+using DcsTranslationTool.Application.Contracts;
+using DcsTranslationTool.Presentation.Wpf.Services;
+using DcsTranslationTool.Presentation.Wpf.Services.Abstractions;
+
+using Moq;
+
+namespace DcsTranslationTool.Presentation.Wpf.Tests.Services;
+
+public sealed class DownloadWorkflowServiceTests {
+    [Fact]
+    public async Task DownloadFilesAsyncは対象が空の場合に成功を返す() {
+        var loggerMock = new Mock<ILoggingService>();
+        var sut = new DownloadWorkflowService( loggerMock.Object );
+
+        var result = await sut.DownloadFilesAsync(
+            [],
+            "translate",
+            TestContext.Current.CancellationToken
+        );
+
+        Assert.True( result.IsSuccess );
+        Assert.Empty( result.Events );
+    }
+
+    [Fact]
+    public async Task DownloadFilesAsyncはキャンセル時にOperationCanceledExceptionを送出する() {
+        var loggerMock = new Mock<ILoggingService>();
+        var sut = new DownloadWorkflowService( loggerMock.Object );
+
+        using var cancellationTokenSource = new CancellationTokenSource();
+        await cancellationTokenSource.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>( async () => await sut.DownloadFilesAsync(
+            [new ApiDownloadFilePathsItem( "https://example.invalid/file.lua", "DCSWorld/Mods/aircraft/A10C/L10N/file.lua" )],
+            "translate",
+            cancellationTokenSource.Token
+        ) );
+    }
+}


### PR DESCRIPTION
## 📌 概要

<!-- このPRの目的・背景を簡潔に書いてください -->
進捗通知をリアルタイム配信に統一しキャンセル制御を安定化

## 🛠 変更内容

<!-- このPRで加えた変更をリストアップしてください -->
- IProgress<WorkflowEvent> を導入して Download/Apply の進捗を逐次通知
- キャンセル時も in-flight タスク完了待機後に中断を伝播
- DownloadViewModel の進捗二重反映を防止
- 関連テストと ISSUES.txt を更新

## 留意点

<!-- このPRを使用するうえで注意すべきことをリストアップしてください。 -->
<!-- 必要がなければ N/A としてください -->
Closes #47