### PR TITLE
refactor(presentation): Upload/Download ViewModel の共通処理を基底クラスへ抽出

### DIFF
--- a/src/DcsTranslationTool.Presentation.Wpf/Features/Common/FileEntryTabsViewModelBase.cs
+++ b/src/DcsTranslationTool.Presentation.Wpf/Features/Common/FileEntryTabsViewModelBase.cs
@@ -1,0 +1,370 @@
+using System.Collections.ObjectModel;
+
+using Caliburn.Micro;
+
+using DcsTranslationTool.Application.Interfaces;
+using DcsTranslationTool.Application.Results;
+using DcsTranslationTool.Presentation.Wpf.Services;
+using DcsTranslationTool.Presentation.Wpf.Services.Abstractions;
+using DcsTranslationTool.Presentation.Wpf.UI.Enums;
+using DcsTranslationTool.Presentation.Wpf.UI.Interfaces;
+using DcsTranslationTool.Presentation.Wpf.ViewModels;
+using DcsTranslationTool.Shared.Models;
+
+namespace DcsTranslationTool.Presentation.Wpf.Features.Common;
+
+/// <summary>
+/// Upload/Download で共有するツリー表示の共通状態と同期処理を提供する。
+/// </summary>
+public abstract class FileEntryTabsViewModelBase(
+    IApiService apiService,
+    IDispatcherService dispatcherService,
+    IFileEntryService fileEntryService,
+    IFileEntryWatcherLifecycle fileEntryWatcherLifecycle,
+    IFileEntryTreeService fileEntryTreeService,
+    ILoggingService logger,
+    ISnackbarService snackbarService
+) : Screen, IActivate {
+    private IReadOnlyList<FileEntry> _localEntries = [];
+    private IReadOnlyList<FileEntry> _repoEntries = [];
+    private ObservableCollection<TabItemViewModel> _tabs = [];
+    private int _selectedTabIndex;
+    private IFilterViewModel _filter = new FilterViewModel( logger );
+    private bool _isFetching;
+    private Func<IReadOnlyList<FileEntry>, Task>? _entriesChangedHandler;
+    private EventHandler? _filtersChangedHandler;
+
+    /// <summary>
+    /// ローカル側のエントリ一覧を取得または設定する。
+    /// </summary>
+    public IReadOnlyList<FileEntry> LocalEntries {
+        get => _localEntries;
+        protected set => Set( ref _localEntries, value );
+    }
+
+    /// <summary>
+    /// リポジトリ側のエントリ一覧を取得または設定する。
+    /// </summary>
+    public IReadOnlyList<FileEntry> RepoEntries {
+        get => _repoEntries;
+        protected set => Set( ref _repoEntries, value );
+    }
+
+    /// <summary>
+    /// タブ一覧を取得または設定する。
+    /// </summary>
+    public ObservableCollection<TabItemViewModel> Tabs {
+        get => _tabs;
+        protected set => Set( ref _tabs, value );
+    }
+
+    /// <summary>
+    /// 選択中タブのインデックスを取得または設定する。
+    /// </summary>
+    public int SelectedTabIndex {
+        get => _selectedTabIndex;
+        set {
+            if(!Set( ref _selectedTabIndex, value )) {
+                return;
+            }
+
+            OnSelectedTabIndexChanged();
+        }
+    }
+
+    /// <summary>
+    /// 表示フィルタを取得または設定する。
+    /// </summary>
+    public IFilterViewModel Filter {
+        get => _filter;
+        set => Set( ref _filter, value );
+    }
+
+    /// <summary>
+    /// 取得処理中であるかどうかを取得または設定する。
+    /// </summary>
+    public bool IsFetching {
+        get => _isFetching;
+        set {
+            if(!Set( ref _isFetching, value )) {
+                return;
+            }
+
+            NotifyOfPropertyChange( nameof( IsTreeInteractionEnabled ) );
+            OnIsFetchingChanged();
+        }
+    }
+
+    /// <summary>
+    /// ツリー操作可否を取得する。
+    /// </summary>
+    public bool IsTreeInteractionEnabled => IsTreeInteractionEnabledCore();
+
+    /// <summary>
+    /// ログ出力サービスを取得する。
+    /// </summary>
+    protected ILoggingService Logger => logger;
+
+    /// <summary>
+    /// UI スレッドディスパッチサービスを取得する。
+    /// </summary>
+    protected IDispatcherService DispatcherService => dispatcherService;
+
+    /// <summary>
+    /// ファイルエントリサービスを取得する。
+    /// </summary>
+    protected IFileEntryService FileEntryService => fileEntryService;
+
+    /// <summary>
+    /// API サービスを取得する。
+    /// </summary>
+    protected IApiService ApiService => apiService;
+
+    /// <summary>
+    /// スナックバーサービスを取得する。
+    /// </summary>
+    protected ISnackbarService SnackbarService => snackbarService;
+
+    /// <summary>
+    /// ViewModel 表示名を取得する。
+    /// </summary>
+    protected abstract string ViewModelName { get; }
+
+    /// <summary>
+    /// タブ生成モードを取得する。
+    /// </summary>
+    protected abstract ChangeTypeMode TreeMode { get; }
+
+    /// <summary>
+    /// ガード関連プロパティの更新通知を行う。
+    /// </summary>
+    protected abstract void NotifyGuardProperties();
+
+    /// <summary>
+    /// 画面アクティブ時に初期化を行う。
+    /// </summary>
+    /// <param name="cancellationToken">キャンセルトークン。</param>
+    /// <returns>非同期タスク。</returns>
+    public async Task ActivateAsync( CancellationToken cancellationToken ) {
+        logger.Info( $"{ViewModelName} をアクティブ化する。" );
+        _ = OnDeactivateAsync( close: false, cancellationToken );
+
+        _entriesChangedHandler = entries => HandleEntriesChangedAsync( entries );
+        fileEntryService.EntriesChanged += _entriesChangedHandler;
+
+        _filtersChangedHandler = ( _, _ ) => ApplyFilter();
+        Filter.FiltersChanged += _filtersChangedHandler;
+
+        fileEntryWatcherLifecycle.StartWatching();
+
+        await Fetch();
+
+        await base.OnActivatedAsync( cancellationToken );
+        logger.Info( $"{ViewModelName} のアクティブ化が完了した。" );
+    }
+
+    /// <summary>
+    /// 画面非アクティブ時に購読解除とクリーンアップを行う。
+    /// </summary>
+    /// <param name="close">閉じるかどうか。</param>
+    /// <param name="cancellationToken">キャンセルトークン。</param>
+    /// <returns>非同期タスク。</returns>
+    protected override async Task OnDeactivateAsync( bool close, CancellationToken cancellationToken ) {
+        logger.Info( $"{ViewModelName} を非アクティブ化する。Close={close}" );
+        if(_entriesChangedHandler is not null) {
+            fileEntryService.EntriesChanged -= _entriesChangedHandler;
+            _entriesChangedHandler = null;
+            logger.Info( "ファイルエントリの購読を解除した。" );
+        }
+
+        if(_filtersChangedHandler is not null) {
+            Filter.FiltersChanged -= _filtersChangedHandler;
+            _filtersChangedHandler = null;
+            logger.Info( "フィルタ変更イベントの購読を解除した。" );
+        }
+
+        fileEntryWatcherLifecycle.StopWatching();
+        snackbarService.Clear();
+        logger.Info( "リソースを解放した。" );
+
+        await base.OnDeactivateAsync( close, cancellationToken );
+    }
+
+    /// <summary>
+    /// リポジトリからツリーを取得する。
+    /// </summary>
+    /// <returns>非同期タスク。</returns>
+    public async Task Fetch() {
+        logger.Info( "ファイル一覧の取得を開始する。" );
+        IsFetching = true;
+        try {
+            var repoResult = await apiService.GetTreeAsync();
+            if(repoResult.IsFailed) {
+                var reason = repoResult.Errors.Count > 0 ? repoResult.Errors[0].Message : null;
+                var message = ResultNotificationPolicy.GetTreeFetchFailureMessage( repoResult.GetFirstErrorKind() );
+                logger.Warn( $"リポジトリのファイル一覧取得が失敗した。Reason={reason}" );
+                await dispatcherService.InvokeAsync( () => {
+                    snackbarService.Show( message );
+                    return Task.CompletedTask;
+                } );
+                return;
+            }
+
+            RepoEntries = [.. repoResult.Value];
+            logger.Info( $"ファイル一覧を取得した。件数={RepoEntries.Count}" );
+            RefreshTabs();
+            await dispatcherService.InvokeAsync( () => {
+                snackbarService.Show( "ファイル一覧の取得が完了しました" );
+                return Task.CompletedTask;
+            } );
+        }
+        catch(Exception ex) {
+            logger.Error( "ファイル一覧取得処理で例外が発生した。", ex );
+            await dispatcherService.InvokeAsync( () => {
+                snackbarService.Show( "取得処理で例外が発生しました" );
+                return Task.CompletedTask;
+            } );
+        }
+        finally {
+            IsFetching = false;
+            logger.Info( "ファイル一覧取得処理を終了した。" );
+        }
+    }
+
+    /// <summary>
+    /// 直近のローカルエントリを再取得して表示へ反映する。
+    /// </summary>
+    /// <returns>非同期タスク。</returns>
+    protected async Task RefreshLocalEntriesAsync() {
+        var entries = await fileEntryService.GetEntriesAsync();
+        if(entries is null) {
+            logger.Warn( "ローカルエントリの取得結果が null のため処理を中断する。" );
+            return;
+        }
+
+        if(entries.IsFailed) {
+            logger.Warn( "ローカルエントリの再取得に失敗した。" );
+            return;
+        }
+
+        await dispatcherService.InvokeAsync( () => {
+            LocalEntries = entries.Value;
+            RefreshTabs();
+            return Task.CompletedTask;
+        } );
+    }
+
+    /// <summary>
+    /// EntriesChanged の購読を一時停止する。
+    /// </summary>
+    protected void SuspendEntriesChangedSubscription() {
+        if(_entriesChangedHandler is null) {
+            return;
+        }
+
+        fileEntryService.EntriesChanged -= _entriesChangedHandler;
+    }
+
+    /// <summary>
+    /// EntriesChanged の購読を再開する。
+    /// </summary>
+    protected void ResumeEntriesChangedSubscription() {
+        if(_entriesChangedHandler is null) {
+            return;
+        }
+
+        fileEntryService.EntriesChanged += _entriesChangedHandler;
+    }
+
+    /// <summary>
+    /// 現在タブでチェック済み項目が存在するかを判定する。
+    /// </summary>
+    /// <returns>1件以上チェック済みの場合は <see langword="true"/>。</returns>
+    protected bool HasCheckedEntries() =>
+        Tabs.Count > 0 &&
+        SelectedTabIndex >= 0 &&
+        SelectedTabIndex < Tabs.Count &&
+        Tabs[SelectedTabIndex].Root.CheckState != false;
+
+    /// <summary>
+    /// 現在のフィルタ条件を適用する。
+    /// </summary>
+    protected void ApplyFilter() {
+        var types = Filter.GetActiveTypes().ToHashSet();
+        var activeTypes = string.Join( ",", types.Select( type => type?.ToString() ?? "null" ) );
+        logger.Info( $"フィルタを適用する。ActiveTypes={activeTypes}" );
+        fileEntryTreeService.ApplyFilter( Tabs, types );
+        NotifyGuardProperties();
+        logger.Info( "フィルタ適用が完了した。" );
+    }
+
+    /// <summary>
+    /// リポジトリとローカルのエントリをマージしてタブを再構築する。
+    /// </summary>
+    protected void RefreshTabs() {
+        var tabIndex = SelectedTabIndex;
+        logger.Info( $"タブを再構築する。LocalCount={LocalEntries.Count}, RepoCount={RepoEntries.Count}, SelectedIndex={tabIndex}" );
+
+        var tabs = fileEntryTreeService.BuildTabs( LocalEntries, RepoEntries, TreeMode );
+
+        foreach(var tab in Tabs) {
+            tab.Root.CheckStateChanged -= OnRootCheckStateChanged;
+        }
+
+        Tabs.Clear();
+        foreach(var tab in tabs) {
+            Tabs.Add( tab );
+        }
+
+        foreach(var tab in Tabs) {
+            tab.Root.CheckStateChanged += OnRootCheckStateChanged;
+        }
+
+        SelectedTabIndex = Tabs.Count == 0 ? 0 : Math.Clamp( tabIndex, 0, Tabs.Count - 1 );
+        ApplyFilter();
+        logger.Info( $"タブの再構築が完了した。TabCount={Tabs.Count}, SelectedIndex={SelectedTabIndex}" );
+    }
+
+    /// <summary>
+    /// ツリー操作可否の判定を提供する。
+    /// </summary>
+    /// <returns>操作可能の場合は <see langword="true"/>。</returns>
+    protected virtual bool IsTreeInteractionEnabledCore() => !IsFetching;
+
+    /// <summary>
+    /// EntriesChanged イベントを無視するかどうかを判定する。
+    /// </summary>
+    /// <returns>無視する場合は <see langword="true"/>。</returns>
+    protected virtual bool ShouldIgnoreEntriesChanged() => false;
+
+    /// <summary>
+    /// SelectedTabIndex の変更時処理を提供する。
+    /// </summary>
+    protected virtual void OnSelectedTabIndexChanged() {
+    }
+
+    /// <summary>
+    /// IsFetching の変更時処理を提供する。
+    /// </summary>
+    protected virtual void OnIsFetchingChanged() {
+    }
+
+    private Task HandleEntriesChangedAsync( IReadOnlyList<FileEntry> entries ) {
+        if(ShouldIgnoreEntriesChanged()) {
+            return Task.CompletedTask;
+        }
+
+        return dispatcherService.InvokeAsync( () => {
+            logger.Info( $"EntriesChanged を受信した。件数={entries.Count}" );
+            LocalEntries = entries;
+            RefreshTabs();
+            return Task.CompletedTask;
+        } );
+    }
+
+    private void OnRootCheckStateChanged( object? sender, bool? e ) {
+        _ = sender;
+        NotifyGuardProperties();
+        logger.Info( $"ルートチェック状態が変化した。SelectedIndex={SelectedTabIndex}, NewState={e}" );
+    }
+}

--- a/src/DcsTranslationTool.Presentation.Wpf/Features/Download/DownloadViewModel.cs
+++ b/src/DcsTranslationTool.Presentation.Wpf/Features/Download/DownloadViewModel.cs
@@ -1,19 +1,14 @@
-using System.Collections.ObjectModel;
 using System.IO;
-
-using Caliburn.Micro;
 
 using DcsTranslationTool.Application.Contracts;
 using DcsTranslationTool.Application.Interfaces;
 using DcsTranslationTool.Application.Results;
 using DcsTranslationTool.Domain.Models;
+using DcsTranslationTool.Presentation.Wpf.Features.Common;
 using DcsTranslationTool.Presentation.Wpf.Services;
 using DcsTranslationTool.Presentation.Wpf.Services.Abstractions;
 using DcsTranslationTool.Presentation.Wpf.UI.Enums;
-using DcsTranslationTool.Presentation.Wpf.UI.Extensions;
 using DcsTranslationTool.Presentation.Wpf.UI.Interfaces;
-using DcsTranslationTool.Presentation.Wpf.ViewModels;
-using DcsTranslationTool.Shared.Models;
 
 namespace DcsTranslationTool.Presentation.Wpf.Features.Download;
 
@@ -31,26 +26,18 @@ public class DownloadViewModel(
     ILoggingService logger,
     ISnackbarService snackbarService,
     ISystemService systemService
-) : Screen, IActivate {
+) : FileEntryTabsViewModelBase(
+    apiService,
+    dispatcherService,
+    fileEntryService,
+    fileEntryWatcherLifecycle,
+    fileEntryTreeService,
+    logger,
+    snackbarService
+) {
 
     #region Fields
 
-    /// <summary>ローカル側のエントリ一覧</summary>
-    private IReadOnlyList<FileEntry> _localEntries = [];
-
-    /// <summary>リポジトリ側のエントリ一覧</summary>
-    private IReadOnlyList<FileEntry> _repoEntries = [];
-
-    ///<summary>全てのタブ情報を取得する。</summary>
-    private ObservableCollection<TabItemViewModel> _tabs = [];
-
-    ///<summary>現在選択されているタブ。</summary>
-    private int _selectedTabIndex;
-
-    /// <summary>ファイルのフィルタ状態を取得するプロパティ。</summary>
-    private IFilterViewModel _filter  = new FilterViewModel( logger );
-
-    private bool _isFetching;
     private bool _isDownloading;
     private double _downloadedProgress = 0.0;
     private bool _isApplying;
@@ -58,17 +45,13 @@ public class DownloadViewModel(
     private bool _suppressEntriesChanged;
     private DownloadWorkflowUiAdapter? _uiAdapter;
 
-    // イベント
-    private Func<IReadOnlyList<FileEntry>, Task>? _entriesChangedHandler;
-    private EventHandler? _filtersChangedHandler;
-
     /// <summary>
     /// Download 画面向けの UI 更新アダプタを取得する。
     /// </summary>
     private DownloadWorkflowUiAdapter UiAdapter =>
         _uiAdapter ??= new(
-            dispatcherService,
-            snackbarService,
+            DispatcherService,
+            SnackbarService,
             value => DownloadedProgress = value,
             value => AppliedProgress = value
         );
@@ -77,58 +60,6 @@ public class DownloadViewModel(
     #endregion
 
     #region Properties
-
-    /// <summary>
-    /// ローカル側のエントリ一覧
-    /// </summary>
-    public IReadOnlyList<FileEntry> LocalEntries {
-        get => _localEntries;
-        private set => Set( ref _localEntries, value );
-    }
-
-    /// <summary>
-    /// リポジトリ側のエントリ一覧
-    /// </summary>
-    public IReadOnlyList<FileEntry> RepoEntries {
-        get => _repoEntries;
-        private set => Set( ref _repoEntries, value );
-    }
-
-    /// <summary>
-    /// 全てのタブ
-    /// </summary>
-    public ObservableCollection<TabItemViewModel> Tabs {
-        get => _tabs;
-        private set => Set( ref _tabs, value );
-    }
-
-    /// <summary>
-    /// 選択中のタブインデックス
-    /// </summary>
-    public int SelectedTabIndex {
-        get => _selectedTabIndex;
-        set {
-            if(!Set( ref _selectedTabIndex, value )) return;
-            NotifyOfPropertyChange( nameof( CanDownload ) );
-            NotifyOfPropertyChange( nameof( CanApply ) );
-        }
-    }
-
-    /// <summary>
-    /// ファイルのフィルタ状態
-    /// </summary>
-    public IFilterViewModel Filter {
-        get => _filter;
-        set => Set( ref _filter, value );
-    }
-
-    public bool IsFetching {
-        get => _isFetching;
-        set {
-            if(!Set( ref _isFetching, value )) return;
-            NotifyOfPropertyChange( nameof( IsTreeInteractionEnabled ) );
-        }
-    }
 
     public bool IsDownloading {
         get => _isDownloading;
@@ -163,151 +94,38 @@ public class DownloadViewModel(
     /// <summary>
     /// ダウンロード可能か
     /// </summary>
-    public bool CanDownload => !IsDownloading && HasChecked();
+    public bool CanDownload => !IsDownloading && HasCheckedEntries();
 
     /// <summary>
     /// 適用可能か
     /// </summary>
-    public bool CanApply => !IsApplying && HasChecked();
-
-    /// <summary>
-    /// ツリー操作が許可されているか。
-    /// </summary>
-    public bool IsTreeInteractionEnabled => !IsFetching && !IsDownloading && !IsApplying;
-
-    #endregion
-
-    #region Lifecycle
-
-    /// <summary>
-    /// 画面アクティブ時に初期化を行う。
-    /// </summary>
-    /// <param name="cancellationToken">キャンセル トークン</param>
-    /// <returns>非同期タスク</returns>
-    public async Task ActivateAsync( CancellationToken cancellationToken ) {
-        logger.Info( "DownloadViewModel をアクティブ化する。" );
-        // 既存購読を解除してから再購読する
-        _ = OnDeactivateAsync( close: false, cancellationToken );
-
-        _entriesChangedHandler = entries => {
-            if(_suppressEntriesChanged) {
-                logger.Info( "ダウンロード中のため EntriesChanged を即時破棄する。" );
-                return Task.CompletedTask;
-            }
-            return dispatcherService.InvokeAsync( () => {
-                logger.Info( $"EntriesChanged を受信した。件数={entries.Count}" );
-                LocalEntries = entries;
-                RefreshTabs();
-                return Task.CompletedTask;
-            } );
-        };
-        fileEntryService.EntriesChanged += _entriesChangedHandler!;
-
-        _filtersChangedHandler = ( _, _ ) => ApplyFilter();
-        Filter.FiltersChanged += _filtersChangedHandler;
-
-        fileEntryWatcherLifecycle.StartWatching();
-
-        // 起動時取得は待たずに開始する
-        await Fetch();
-
-        await base.OnActivatedAsync( cancellationToken );
-        logger.Info( "DownloadViewModel のアクティブ化が完了した。" );
-    }
-
-    /// <summary>
-    /// 画面非アクティブ時に購読解除とクリーンアップを行う。
-    /// </summary>
-    /// <param name="close">閉じるかどうか</param>
-    /// <param name="cancellationToken">キャンセル トークン</param>
-    /// <returns>非同期タスク</returns>
-    protected override async Task OnDeactivateAsync( bool close, CancellationToken cancellationToken ) {
-        logger.Info( $"DownloadViewModel を非アクティブ化する。Close={close}" );
-        if(_entriesChangedHandler is not null) {
-            fileEntryService.EntriesChanged -= _entriesChangedHandler;
-            _entriesChangedHandler = null;
-            logger.Info( "ファイルエントリの購読を解除した。" );
-        }
-
-        if(_filtersChangedHandler is not null) {
-            Filter.FiltersChanged -= _filtersChangedHandler;
-            _filtersChangedHandler = null;
-            logger.Info( "フィルタ変更イベントの購読を解除した。" );
-        }
-
-        fileEntryWatcherLifecycle.StopWatching();
-        snackbarService.Clear();
-        logger.Info( "リソースを解放した。" );
-
-        await base.OnDeactivateAsync( close, cancellationToken );
-    }
+    public bool CanApply => !IsApplying && HasCheckedEntries();
 
     #endregion
 
     #region Actions
 
     /// <summary>
-    /// リポジトリからツリーを取得する
-    /// </summary>
-    /// <returns>非同期タスク</returns>
-    /// <exception cref="InvalidOperationException">取得失敗時</exception>
-    public async Task Fetch() {
-        logger.Info( "ファイル一覧の取得を開始する。" );
-        IsFetching = true;
-        try {
-            var repoResult = await apiService.GetTreeAsync();
-            if(repoResult.IsFailed) {
-                var reason = repoResult.Errors.Count > 0 ? repoResult.Errors[0].Message : null;
-                var message = ResultNotificationPolicy.GetTreeFetchFailureMessage( repoResult.GetFirstErrorKind() );
-                logger.Error( $"リポジトリのファイル一覧取得が失敗した。Reason={reason}" );
-                await dispatcherService.InvokeAsync( () => {
-                    snackbarService.Show( message );
-                    return Task.CompletedTask;
-                } );
-                return;
-            }
-            RepoEntries = [.. repoResult.Value];
-            logger.Info( $"ファイル一覧を取得した。件数={RepoEntries.Count}" );
-            RefreshTabs();
-            await dispatcherService.InvokeAsync( () => {
-                snackbarService.Show( "ファイル一覧の取得が完了しました" );
-                return Task.CompletedTask;
-            } );
-        }
-        catch(Exception ex) {
-            logger.Error( "ファイル一覧取得処理で例外が発生した。", ex );
-            await dispatcherService.InvokeAsync( () => {
-                snackbarService.Show( "取得処理で例外が発生しました" );
-                return Task.CompletedTask;
-            } );
-        }
-        finally {
-            IsFetching = false;
-            logger.Info( "ファイル一覧取得処理を終了した。" );
-        }
-    }
-
-    /// <summary>
     /// チェック状態のファイルをダウンロードする
     /// </summary>
     /// <returns>非同期タスク</returns>
     public async Task Download() {
-        logger.Info( "ダウンロード処理を開始する。" );
+        Logger.Info( "ダウンロード処理を開始する。" );
         if(!CanDownload) {
-            logger.Warn( "ダウンロードは現在許可されていないため処理を中断する。" );
+            Logger.Warn( "ダウンロードは現在許可されていないため処理を中断する。" );
             return;
         }
 
         var saveRootPath = appSettingsService.Settings.TranslateFileDir;
         if(string.IsNullOrWhiteSpace( saveRootPath )) {
-            logger.Warn( "保存先ディレクトリが設定されていないため保存を中断する。" );
+            Logger.Warn( "保存先ディレクトリが設定されていないため保存を中断する。" );
             await UiAdapter.ShowSnackbarAsync( "保存先フォルダーが設定されていません" );
             return;
         }
 
         await ExecuteWithEntriesChangedSuppressedAsync( isDownload: true, async () => {
             if(Tabs.Count == 0 || SelectedTabIndex < 0 || SelectedTabIndex >= Tabs.Count) {
-                logger.Warn( "タブが選択されていないためダウンロードを中断する。" );
+                Logger.Warn( "タブが選択されていないためダウンロードを中断する。" );
                 await UiAdapter.ShowSnackbarAsync( "タブが選択されていません" );
                 return;
             }
@@ -315,36 +133,36 @@ public class DownloadViewModel(
             var tab = Tabs[SelectedTabIndex];
             var checkedEntries = tab.GetCheckedEntries();
             if(checkedEntries is null) {
-                logger.Warn( "チェックされたエントリが存在しない。" );
+                Logger.Warn( "チェックされたエントリが存在しない。" );
                 await UiAdapter.ShowSnackbarAsync( "ダウンロード対象が有りません" );
                 return;
             }
 
             var targetEntries = checkedEntries.Where( e => !e.IsDirectory ).ToList();
             if(targetEntries.Count == 0) {
-                logger.Warn( "ダウンロード対象のファイルが存在しない。" );
+                Logger.Warn( "ダウンロード対象のファイルが存在しない。" );
                 await UiAdapter.ShowSnackbarAsync( "ダウンロード対象が有りません" );
                 return;
             }
-            logger.Info( $"ダウンロード対象を特定した。件数={targetEntries.Count}" );
+            Logger.Info( $"ダウンロード対象を特定した。件数={targetEntries.Count}" );
 
             IReadOnlyList<string> paths = targetEntries.ConvertAll( e => e.Path );
-            var pathResult = await apiService.DownloadFilePathsAsync(
+            var pathResult = await ApiService.DownloadFilePathsAsync(
                 new ApiDownloadFilePathsRequest( paths, null )
             );
             if(pathResult.IsFailed) {
                 var reason = pathResult.Errors.Count > 0 ? pathResult.Errors[0].Message : null;
                 var message = ResultNotificationPolicy.GetDownloadPathFailureMessage( pathResult.GetFirstErrorKind() );
-                logger.Error( $"ダウンロードURLの取得に失敗した。Reason={reason}" );
+                Logger.Error( $"ダウンロードURLの取得に失敗した。Reason={reason}" );
                 await UiAdapter.ShowSnackbarAsync( message );
                 return;
             }
 
             var downloadItems = pathResult.Value.Items.ToArray();
-            logger.Info( $"ダウンロードURLを取得した。{downloadItems.Length}件" );
+            Logger.Info( $"ダウンロードURLを取得した。{downloadItems.Length}件" );
 
             if(downloadItems.Length == 0) {
-                logger.Info( "ダウンロード対象が最新のため保存をスキップする。" );
+                Logger.Info( "ダウンロード対象が最新のため保存をスキップする。" );
                 await UiAdapter.ShowSnackbarAsync( "対象ファイルは最新です" );
                 return;
             }
@@ -358,15 +176,15 @@ public class DownloadViewModel(
     /// </summary>
     /// <returns>非同期タスク</returns>
     public async Task Apply() {
-        logger.Info( "適用処理を開始する。" );
+        Logger.Info( "適用処理を開始する。" );
         if(!CanApply) {
-            logger.Warn( "適用は現在許可されていないため処理を中断する。" );
+            Logger.Warn( "適用は現在許可されていないため処理を中断する。" );
             return;
         }
 
         await ExecuteWithEntriesChangedSuppressedAsync( isDownload: false, async () => {
             if(Tabs.Count == 0 || SelectedTabIndex < 0 || SelectedTabIndex >= Tabs.Count) {
-                logger.Warn( "タブが選択されていないため適用処理を中断する。" );
+                Logger.Warn( "タブが選択されていないため適用処理を中断する。" );
                 await UiAdapter.ShowSnackbarAsync( "タブが選択されていません" );
                 return;
             }
@@ -375,11 +193,11 @@ public class DownloadViewModel(
             var targetEntries = GetTargetFileNodes().Where( e => !e.IsDirectory ).ToList();
 
             if(targetEntries.Count == 0) {
-                logger.Warn( "適用対象のファイルが存在しない。" );
+                Logger.Warn( "適用対象のファイルが存在しない。" );
                 await UiAdapter.ShowSnackbarAsync( "対象が有りません" );
                 return;
             }
-            logger.Info( $"適用対象を特定した。件数={targetEntries.Count}" );
+            Logger.Info( $"適用対象を特定した。件数={targetEntries.Count}" );
 
             string rootPath = tab.TabType switch
             {
@@ -390,14 +208,14 @@ public class DownloadViewModel(
             };
 
             if(string.IsNullOrWhiteSpace( rootPath )) {
-                logger.Warn( "適用先ディレクトリが設定されていないため処理を中断する。" );
+                Logger.Warn( "適用先ディレクトリが設定されていないため処理を中断する。" );
                 await UiAdapter.ShowSnackbarAsync( "適用先ディレクトリを設定してください" );
                 return;
             }
 
             var rootFullPath = Path.GetFullPath( rootPath );
             if(!Directory.Exists( rootFullPath )) {
-                logger.Warn( $"適用先ディレクトリが存在しない。Directory={rootFullPath}" );
+                Logger.Warn( $"適用先ディレクトリが存在しない。Directory={rootFullPath}" );
                 await UiAdapter.ShowSnackbarAsync( "適用先ディレクトリが存在しません" );
                 return;
             }
@@ -407,7 +225,7 @@ public class DownloadViewModel(
 
             var translateRoot = appSettingsService.Settings.TranslateFileDir;
             if(string.IsNullOrWhiteSpace( translateRoot )) {
-                logger.Warn( "翻訳ディレクトリが未設定のため処理を中断する。" );
+                Logger.Warn( "翻訳ディレクトリが未設定のため処理を中断する。" );
                 await UiAdapter.ShowSnackbarAsync( "翻訳ディレクトリを設定してください" );
                 return;
             }
@@ -431,29 +249,11 @@ public class DownloadViewModel(
         } );
     }
 
-    private async Task RefreshLocalEntriesAsync() {
-        var entries = await fileEntryService.GetEntriesAsync();
-        if(entries is null) {
-            logger.Warn( "ダウンロード完了後のエントリ取得結果が null のため処理を中断する。" );
-            return;
-        }
-        if(entries.IsFailed) {
-            logger.Warn( "ダウンロード完了後のエントリ再取得に失敗した。" );
-            return;
-        }
-
-        await dispatcherService.InvokeAsync( () => {
-            LocalEntries = entries.Value;
-            RefreshTabs();
-            return Task.CompletedTask;
-        } );
-    }
-
     /// <summary>
     /// 翻訳ファイルの管理ディレクトリをエクスプローラーで開く
     /// </summary>
     public void OpenDirectory() {
-        logger.Info( $"翻訳ファイルディレクトリを開く。Directory={appSettingsService.Settings.TranslateFileDir}" );
+        Logger.Info( $"翻訳ファイルディレクトリを開く。Directory={appSettingsService.Settings.TranslateFileDir}" );
         systemService.OpenDirectory( appSettingsService.Settings.TranslateFileDir );
     }
 
@@ -465,10 +265,7 @@ public class DownloadViewModel(
     /// <returns>非同期タスク。</returns>
     private async Task ExecuteWithEntriesChangedSuppressedAsync( bool isDownload, Func<Task> action ) {
         _suppressEntriesChanged = true;
-        var entriesChangedHandler = _entriesChangedHandler;
-        if(entriesChangedHandler is not null) {
-            fileEntryService.EntriesChanged -= entriesChangedHandler;
-        }
+        SuspendEntriesChangedSubscription();
 
         if(isDownload) {
             IsDownloading = true;
@@ -494,60 +291,13 @@ public class DownloadViewModel(
             }
 
             _suppressEntriesChanged = false;
-            if(entriesChangedHandler is not null) {
-                fileEntryService.EntriesChanged += entriesChangedHandler;
-            }
+            ResumeEntriesChangedSubscription();
 
             await RefreshLocalEntriesAsync();
             NotifyOfPropertyChange( nameof( CanDownload ) );
             NotifyOfPropertyChange( nameof( CanApply ) );
-            logger.Info( $"{(isDownload ? "ダウンロード" : "適用")}処理を終了した。" );
+            Logger.Info( $"{(isDownload ? "ダウンロード" : "適用")}処理を終了した。" );
         }
-    }
-
-    /// <summary>
-    /// 現在のタブでチェックありかを判定する
-    /// </summary>
-    /// <returns>チェックが1つ以上なら true</returns>
-    private bool HasChecked() =>
-        Tabs.Count > 0 &&
-        SelectedTabIndex >= 0 &&
-        SelectedTabIndex < Tabs.Count &&
-        Tabs[SelectedTabIndex].Root.CheckState != false;
-
-    /// <summary>
-    /// リポジトリとローカルのエントリをマージしてタブを再構築する
-    /// </summary>
-    private void RefreshTabs() {
-        var tabIndex = SelectedTabIndex;
-        logger.Info( $"タブを再構築する。LocalCount={LocalEntries.Count}, RepoCount={RepoEntries.Count}, SelectedIndex={tabIndex}" );
-
-        var tabs = fileEntryTreeService.BuildTabs( LocalEntries, RepoEntries, ChangeTypeMode.Download );
-
-        foreach(var t in Tabs) t.Root.CheckStateChanged -= OnRootCheckStateChanged;
-        Tabs.Clear();
-        foreach(var t in tabs) Tabs.Add( t );
-        foreach(var t in Tabs) t.Root.CheckStateChanged += OnRootCheckStateChanged;
-
-        SelectedTabIndex = Tabs.Count == 0 ? 0 : Math.Clamp( tabIndex, 0, Tabs.Count - 1 );
-
-        ApplyFilter();
-        NotifyOfPropertyChange( nameof( CanDownload ) );
-        NotifyOfPropertyChange( nameof( CanApply ) );
-        logger.Info( $"タブの再構築が完了した。TabCount={Tabs.Count}, SelectedIndex={SelectedTabIndex}" );
-    }
-
-    /// <summary>
-    /// ルートノードのチェック状態変化時にガードを更新する
-    /// </summary>
-    /// <param name="sender">送信元</param>
-    /// <param name="e">チェック状態</param>
-    private void OnRootCheckStateChanged( object? sender, bool? e ) {
-        _ = sender;
-        _ = e;
-        NotifyOfPropertyChange( nameof( CanDownload ) );
-        NotifyOfPropertyChange( nameof( CanApply ) );
-        logger.Info( $"ルートチェック状態が変化した。SelectedIndex={SelectedTabIndex}, NewState={e}" );
     }
 
     /// <summary>
@@ -561,18 +311,35 @@ public class DownloadViewModel(
             .Where( e => e.ChangeType is FileChangeType.Modified or FileChangeType.LocalOnly or FileChangeType.RepoOnly );
     }
 
-    /// <summary>
-    /// 現在のフィルタ条件を適用する
-    /// </summary>
-    private void ApplyFilter() {
-        var types = Filter.GetActiveTypes().ToHashSet();
-        var activeTypes = string.Join( ",", types.Select( t => t?.ToString() ?? "null" ) );
-        logger.Info( $"フィルタを適用する。ActiveTypes={activeTypes}" );
-        fileEntryTreeService.ApplyFilter( Tabs, types );
+    /// <inheritdoc />
+    protected override string ViewModelName => nameof( DownloadViewModel );
+
+    /// <inheritdoc />
+    protected override ChangeTypeMode TreeMode => ChangeTypeMode.Download;
+
+    /// <inheritdoc />
+    protected override bool ShouldIgnoreEntriesChanged() {
+        if(!_suppressEntriesChanged) {
+            return false;
+        }
+
+        Logger.Info( "ダウンロード中のため EntriesChanged を即時破棄する。" );
+        return true;
+    }
+
+    /// <inheritdoc />
+    protected override void NotifyGuardProperties() {
         NotifyOfPropertyChange( nameof( CanDownload ) );
         NotifyOfPropertyChange( nameof( CanApply ) );
-        logger.Info( "フィルタ適用が完了した。" );
     }
+
+    /// <inheritdoc />
+    protected override void OnSelectedTabIndexChanged() =>
+        NotifyGuardProperties();
+
+    /// <inheritdoc />
+    protected override bool IsTreeInteractionEnabledCore() =>
+        !IsFetching && !IsDownloading && !IsApplying;
 
     #endregion
 }


### PR DESCRIPTION
## 📌 概要

<!-- このPRの目的・背景を簡潔に書いてください -->
Upload/Download の両 ViewModel に重複していた一覧取得・イベント購読・タブ再構築・フィルタ適用を共通化し、変更漏れを防ぎつつ保守性を向上させた。

## 🛠 変更内容

<!-- このPRで加えた変更をリストアップしてください -->
- src/DcsTranslationTool.Presentation.Wpf/Features/Common/FileEntryTabsViewModelBase.cs を新規追加した。
- 以下の共通処理を基底クラスへ抽出した。
    - Fetch（リポジトリツリー取得と通知）
    - EntriesChanged の購読/解除と反映
    - Tabs の再構築
    - Filter の適用
    - ActivateAsync / OnDeactivateAsync のライフサイクル処理
- UploadViewModel は以下を中心に保持するよう整理した。
    - Create Pull Request ダイアログ表示と関連判定
    - Upload 固有のガード通知
- DownloadViewModel は以下を中心に保持するよう整理した。
    - Download / Apply 実行フロー
    - 実行中の EntriesChanged 抑止ロジック
    - Download 固有のガード通知
- DI で依存を保持する共通基底はプライマリコンストラクタで実装した。

## 留意点

<!-- このPRを使用するうえで注意すべきことをリストアップしてください。 -->
<!-- 必要がなければ N/A としてください -->
- 外部仕様（一覧表示、フィルタ、タブ更新、イベント反映）は変更していない前提で整理している。
- DownloadViewModel の EntriesChanged 抑止（処理中の再入防止）は従来挙動を維持している。
- 動作確認として Presentation.Wpf.Tests を実行し、全件成功を確認した（58 passed）。

Closes #51
