### PR TITLE
refactor(presentation): DownloadViewModel のユースケース境界を明確化

### DIFF
--- a/src/DcsTranslationTool.Presentation.Wpf/Services/Abstractions/ApplyExecutionRequest.cs
+++ b/src/DcsTranslationTool.Presentation.Wpf/Services/Abstractions/ApplyExecutionRequest.cs
@@ -1,0 +1,19 @@
+using DcsTranslationTool.Presentation.Wpf.ViewModels;
+
+namespace DcsTranslationTool.Presentation.Wpf.Services.Abstractions;
+
+/// <summary>
+/// 適用ユースケース実行に必要な入力を表す。
+/// </summary>
+/// <param name="SelectedTab">選択中タブ。</param>
+/// <param name="SourceAircraftDir">航空機ミッションの適用先ルート。</param>
+/// <param name="SourceDlcCampaignDir">DLC キャンペーンの適用先ルート。</param>
+/// <param name="SourceUserMissionDir">ユーザーミッションの適用先ルート。</param>
+/// <param name="TranslateRootPath">翻訳ファイルルート。</param>
+public sealed record ApplyExecutionRequest(
+    TabItemViewModel? SelectedTab,
+    string? SourceAircraftDir,
+    string? SourceDlcCampaignDir,
+    string? SourceUserMissionDir,
+    string? TranslateRootPath
+);

--- a/src/DcsTranslationTool.Presentation.Wpf/Services/Abstractions/DownloadExecutionRequest.cs
+++ b/src/DcsTranslationTool.Presentation.Wpf/Services/Abstractions/DownloadExecutionRequest.cs
@@ -1,0 +1,13 @@
+using DcsTranslationTool.Presentation.Wpf.ViewModels;
+
+namespace DcsTranslationTool.Presentation.Wpf.Services.Abstractions;
+
+/// <summary>
+/// ダウンロードユースケース実行に必要な入力を表す。
+/// </summary>
+/// <param name="SelectedTab">選択中タブ。</param>
+/// <param name="SaveRootPath">翻訳ファイル保存先ルート。</param>
+public sealed record DownloadExecutionRequest(
+    TabItemViewModel? SelectedTab,
+    string? SaveRootPath
+);

--- a/src/DcsTranslationTool.Presentation.Wpf/Services/Abstractions/IDownloadWorkflowService.cs
+++ b/src/DcsTranslationTool.Presentation.Wpf/Services/Abstractions/IDownloadWorkflowService.cs
@@ -8,6 +8,34 @@ namespace DcsTranslationTool.Presentation.Wpf.Services.Abstractions;
 /// </summary>
 public interface IDownloadWorkflowService {
     /// <summary>
+    /// ダウンロードユースケースを実行する。
+    /// </summary>
+    /// <param name="request">ダウンロード入力。</param>
+    /// <param name="progressCallback">進捗通知コールバック。</param>
+    /// <param name="cancellationToken">キャンセルトークン。</param>
+    /// <returns>実行結果。</returns>
+    Task<DownloadWorkflowResult> ExecuteDownloadAsync(
+        DownloadExecutionRequest request,
+        Func<double, Task> progressCallback,
+        CancellationToken cancellationToken = default
+    );
+
+    /// <summary>
+    /// 適用ユースケースを実行する。
+    /// </summary>
+    /// <param name="request">適用入力。</param>
+    /// <param name="showSnackbarAsync">通知コールバック。</param>
+    /// <param name="progressCallback">進捗通知コールバック。</param>
+    /// <param name="cancellationToken">キャンセルトークン。</param>
+    /// <returns>実行結果。</returns>
+    Task<ApplyWorkflowResult> ExecuteApplyAsync(
+        ApplyExecutionRequest request,
+        Func<string, Task> showSnackbarAsync,
+        Func<double, Task> progressCallback,
+        CancellationToken cancellationToken = default
+    );
+
+    /// <summary>
     /// ダウンロードURL一覧からファイルを保存する。
     /// </summary>
     /// <param name="items">ダウンロード対象一覧。</param>

--- a/tests/DcsTranslationTool.Presentation.Wpf.Tests/Services/DownloadWorkflowServiceTests.cs
+++ b/tests/DcsTranslationTool.Presentation.Wpf.Tests/Services/DownloadWorkflowServiceTests.cs
@@ -1,3 +1,4 @@
+using DcsTranslationTool.Application.Interfaces;
 using DcsTranslationTool.Presentation.Wpf.Services;
 using DcsTranslationTool.Presentation.Wpf.Services.Abstractions;
 using DcsTranslationTool.Presentation.Wpf.UI.Interfaces;
@@ -9,9 +10,10 @@ namespace DcsTranslationTool.Presentation.Wpf.Tests.Services;
 public sealed class DownloadWorkflowServiceTests {
     [Fact]
     public async Task ApplyAsyncはApplyWorkflowServiceへ委譲する() {
+        var apiService = new Mock<IApiService>( MockBehavior.Strict );
         var logger = new Mock<ILoggingService>();
         var applyWorkflowService = new Mock<IApplyWorkflowService>( MockBehavior.Strict );
-        var sut = new DownloadWorkflowService( logger.Object, applyWorkflowService.Object );
+        var sut = new DownloadWorkflowService( apiService.Object, logger.Object, applyWorkflowService.Object );
 
         var targetEntries = Array.Empty<IFileEntryViewModel>();
         applyWorkflowService


### PR DESCRIPTION
## 📌 概要

<!-- このPRの目的・背景を簡潔に書いてください -->
DownloadViewModel に集約していたダウンロード/適用の入力検証・分岐・実行ロジックを DownloadWorkflowService へ分離し、ViewModel の責務を状態遷移と UI 通知に限定した。

## 🛠 変更内容

<!-- このPRで加えた変更をリストアップしてください -->
- IDownloadWorkflowService にユースケース境界 API を追加した。
- ユースケース入力 DTO を追加した。
    - DownloadExecutionRequest
    - ApplyExecutionRequest
- DownloadWorkflowService に以下を集約した。
    - 選択タブ/対象件数/設定値の検証
    - ダウンロード URL 取得とエラーマッピング
    - 適用先・翻訳ルートのパス検証
    - 実行結果を WorkflowEvent として返却
- DownloadViewModel を簡素化した。
    - 新 API 呼び出しに置換
    - HandleWorkflowEventsAsync で通知/進捗のみ反映
    - GetTargetFileNodes などユースケース詳細ロジックを削除
- テストを新 API に追従した。
    - DownloadViewModelTests
    - DownloadWorkflowServiceTests

## 留意点

<!-- このPRを使用するうえで注意すべきことをリストアップしてください。 -->
<!-- 必要がなければ N/A としてください -->
Closes #53