### PR TITLE
refactor(infrastructure): ApiClient実装をKiota生成クライアント基準に統一

### DIFF
--- a/src/DcsTranslationTool.Composition/packages.lock.json
+++ b/src/DcsTranslationTool.Composition/packages.lock.json
@@ -44,6 +44,14 @@
           "Std.UriTemplate": "2.0.8"
         }
       },
+      "Microsoft.Kiota.Http.HttpClientLibrary": {
+        "type": "Transitive",
+        "resolved": "1.21.2",
+        "contentHash": "rIzUUPjPaCRA7gIsw3vi9Vd8eWjR1UlwBZ9bbuUsgV3Mt4DShbh72W0uZma5UX18HBlfzEXnahyCvPCHAmfTDg==",
+        "dependencies": {
+          "Microsoft.Kiota.Abstractions": "1.21.2"
+        }
+      },
       "Microsoft.Kiota.Serialization.Form": {
         "type": "Transitive",
         "resolved": "1.21.2",
@@ -129,6 +137,7 @@
           "DcsTranslationTool.Shared": "[1.0.0, )",
           "FluentResults": "[4.0.0, )",
           "Microsoft.Kiota.Abstractions": "[1.21.2, )",
+          "Microsoft.Kiota.Http.HttpClientLibrary": "[1.21.2, )",
           "Microsoft.Kiota.Serialization.Form": "[1.21.2, )",
           "Microsoft.Kiota.Serialization.Json": "[1.21.0, )",
           "Microsoft.Kiota.Serialization.Multipart": "[1.21.0, )",

--- a/src/DcsTranslationTool.Infrastructure/DcsTranslationTool.Infrastructure.csproj
+++ b/src/DcsTranslationTool.Infrastructure/DcsTranslationTool.Infrastructure.csproj
@@ -9,6 +9,7 @@
     <ItemGroup>
         <PackageReference Include="FluentResults" Version="4.0.0" />
         <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.21.2" />
+        <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.21.2" />
         <PackageReference Include="Microsoft.Kiota.Serialization.Form" Version="1.21.2" />
         <PackageReference Include="Microsoft.Kiota.Serialization.Json" Version="1.21.0" />
         <PackageReference Include="Microsoft.Kiota.Serialization.Multipart" Version="1.21.0" />

--- a/src/DcsTranslationTool.Infrastructure/Services/ApiService.cs
+++ b/src/DcsTranslationTool.Infrastructure/Services/ApiService.cs
@@ -7,9 +7,18 @@ using System.Text.Json.Serialization;
 using DcsTranslationTool.Application.Contracts;
 using DcsTranslationTool.Application.Interfaces;
 using DcsTranslationTool.Application.Results;
+using DcsTranslationTool.Infrastructure.Http.ApiClient.CreatePr;
+using DcsTranslationTool.Infrastructure.Http.ApiClient.DownloadFilePaths;
+using DcsTranslationTool.Infrastructure.Http.ApiClient.DownloadFiles;
+using DcsTranslationTool.Infrastructure.Http.ApiClient.Health;
 using DcsTranslationTool.Shared.Models;
 
 using FluentResults;
+
+using Microsoft.Kiota.Abstractions.Authentication;
+using Microsoft.Kiota.Http.HttpClientLibrary;
+
+using DcsApiClient = DcsTranslationTool.Infrastructure.Http.ApiClient.ApiClient;
 
 namespace DcsTranslationTool.Infrastructure.Services;
 
@@ -24,22 +33,22 @@ public class ApiService( HttpClient? httpClient = null ) : IApiService {
         Converters = { new JsonStringEnumConverter() },
     };
 
-    private readonly HttpClient _httpClient = InitializeClient( httpClient );
+    private readonly ApiClientContext _apiClientContext = InitializeApiClientContext( httpClient );
 
     /// <summary>APIのヘルスチェックを実行して結果を返却する</summary>
     public async Task<Result<ApiHealth>> GetHealthAsync( CancellationToken cancellationToken = default ) {
         try {
-            using var response = await _httpClient.GetAsync("health", cancellationToken).ConfigureAwait(false);
+            using var response = await _apiClientContext.HttpClient.GetAsync( "health", cancellationToken ).ConfigureAwait( false );
             if(!response.IsSuccessStatusCode)
                 return Result.Fail( ResultErrorFactory.External( $"HTTP {(int)response.StatusCode}: {response.ReasonPhrase}", "API_HTTP_ERROR" ) );
 
-            var payload = await response.Content.ReadFromJsonAsync<HealthResponse>(SerializerOptions, cancellationToken).ConfigureAwait(false);
+            var payload = await response.Content.ReadFromJsonAsync<HealthResponse>( SerializerOptions, cancellationToken ).ConfigureAwait( false );
             if(payload is null)
                 return Result.Fail( ResultErrorFactory.External( "Response body was null.", "API_EMPTY_RESPONSE" ) );
 
             var status = payload.Status switch
             {
-                string value when string.Equals(value, "ok", StringComparison.OrdinalIgnoreCase) => ApiHealthStatus.Ok,
+                string value when string.Equals( value, "ok", StringComparison.OrdinalIgnoreCase ) => ApiHealthStatus.Ok,
                 _ => ApiHealthStatus.Unknown,
             };
 
@@ -53,19 +62,19 @@ public class ApiService( HttpClient? httpClient = null ) : IApiService {
     /// <summary>APIを呼び出してツリー情報を取得しコレクションとして返却する</summary>
     public async Task<Result<IReadOnlyList<FileEntry>>> GetTreeAsync( CancellationToken cancellationToken = default ) {
         try {
-            using var resp = await _httpClient.GetAsync("tree", cancellationToken).ConfigureAwait(false);
+            using var resp = await _apiClientContext.HttpClient.GetAsync( "tree", cancellationToken ).ConfigureAwait( false );
             if(!resp.IsSuccessStatusCode)
                 return Result.Fail( ResultErrorFactory.External( $"HTTP {(int)resp.StatusCode}: {resp.ReasonPhrase}", "API_HTTP_ERROR" ) );
 
-            var payload = await resp.Content.ReadFromJsonAsync<TreeResponse>(SerializerOptions, cancellationToken).ConfigureAwait(false);
+            var payload = await resp.Content.ReadFromJsonAsync<TreeResponse>( SerializerOptions, cancellationToken ).ConfigureAwait( false );
             if(payload?.Data is not { Count: > 0 } data)
                 return Result.Ok<IReadOnlyList<FileEntry>>( Array.Empty<FileEntry>() );
 
-            var entries = new List<FileEntry>(data.Count);
+            var entries = new List<FileEntry>( data.Count );
             foreach(var item in data) {
                 if(item is null || string.IsNullOrWhiteSpace( item.Path )) continue;
-                var name = ExtractName(item.Path);
-                var isDirectory = IsDirectory(item);
+                var name = ExtractName( item.Path );
+                var isDirectory = IsDirectory( item );
                 entries.Add( new FileEntry( name, item.Path, isDirectory, repoSha: item.Sha ) );
             }
             return Result.Ok<IReadOnlyList<FileEntry>>( entries );
@@ -89,21 +98,32 @@ public class ApiService( HttpClient? httpClient = null ) : IApiService {
         var sanitizedPaths = sanitizeResult.Value;
 
         try {
-            var payload = new DownloadFilesRequest( sanitizedPaths );
-            using var message = new HttpRequestMessage( HttpMethod.Post, "download-files" )
-            {
-                Content = JsonContent.Create( payload, options: SerializerOptions ),
-            };
+            var requestInfo = _apiClientContext.ApiClient.DownloadFiles.ToPostRequestInformation(
+                new DownloadFilesPostRequestBody
+                {
+                    Paths = [.. sanitizedPaths],
+                },
+                config => {
+                    if(!string.IsNullOrWhiteSpace( request.ETag ))
+                        config.Headers.TryAdd( "If-None-Match", request.ETag );
+                }
+            );
+
+            using var message = await _apiClientContext.RequestAdapter
+                .ConvertToNativeRequestAsync<HttpRequestMessage>( requestInfo, cancellationToken )
+                .ConfigureAwait( false );
+            if(message is null)
+                return Result.Fail( ResultErrorFactory.External( "Request message was null.", "API_REQUEST_BUILD_ERROR" ) );
 
             message.Headers.Accept.Clear();
             message.Headers.Accept.Add( new MediaTypeWithQualityHeaderValue( "application/zip" ) );
             message.Headers.Accept.Add( new MediaTypeWithQualityHeaderValue( "application/problem+json" ) );
+            if(!string.IsNullOrWhiteSpace( request.ETag ))
+                message.Headers.TryAddWithoutValidation( "If-None-Match", request.ETag );
 
-            if(!string.IsNullOrWhiteSpace( request.ETag )) message.Headers.TryAddWithoutValidation( "If-None-Match", request.ETag );
-
-            using var response = await _httpClient
+            using var response = await _apiClientContext.HttpClient
                 .SendAsync( message, HttpCompletionOption.ResponseHeadersRead, cancellationToken )
-                .ConfigureAwait(false);
+                .ConfigureAwait( false );
 
             if(response.StatusCode == HttpStatusCode.NotModified) {
                 var cached = new ApiDownloadFilesResult(
@@ -119,15 +139,15 @@ public class ApiService( HttpClient? httpClient = null ) : IApiService {
                 return Result.Ok( cached );
             }
 
-            var ensureResult = await EnsureSuccessStatusCodeAsync( response, cancellationToken ).ConfigureAwait(false);
+            var ensureResult = await EnsureSuccessStatusCodeAsync( response, cancellationToken ).ConfigureAwait( false );
             if(ensureResult.IsFailed)
                 return Result.Fail( ensureResult.Errors );
 
-            var content = await response.Content.ReadAsByteArrayAsync( cancellationToken ).ConfigureAwait(false);
+            var content = await response.Content.ReadAsByteArrayAsync( cancellationToken ).ConfigureAwait( false );
             var size = response.Content.Headers.ContentLength ?? content.LongLength;
             var contentType = response.Content.Headers.ContentType?.MediaType;
             var fileName = response.Content.Headers.ContentDisposition?.FileNameStar
-                ?? response.Content.Headers.ContentDisposition?.FileName?.Trim('"');
+                ?? response.Content.Headers.ContentDisposition?.FileName?.Trim( '"' );
             var etag = response.Headers.ETag?.Tag;
 
             var result = new ApiDownloadFilesResult(
@@ -161,44 +181,57 @@ public class ApiService( HttpClient? httpClient = null ) : IApiService {
         var sanitizedPaths = sanitizeResult.Value;
 
         try {
-            var payload = new DownloadFilePathsRequest( sanitizedPaths );
-            using var message = new HttpRequestMessage( HttpMethod.Post, "download-file-paths" )
-            {
-                Content = JsonContent.Create( payload, options: SerializerOptions ),
-            };
+            var requestInfo = _apiClientContext.ApiClient.DownloadFilePaths.ToPostRequestInformation(
+                new DownloadFilePathsPostRequestBody
+                {
+                    Paths = [.. sanitizedPaths],
+                },
+                config => {
+                    config.Headers.TryAdd( "Accept", "application/problem+json" );
+                    if(!string.IsNullOrWhiteSpace( request.ETag ))
+                        config.Headers.TryAdd( "If-None-Match", request.ETag );
+                }
+            );
+
+            using var message = await _apiClientContext.RequestAdapter
+                .ConvertToNativeRequestAsync<HttpRequestMessage>( requestInfo, cancellationToken )
+                .ConfigureAwait( false );
+            if(message is null)
+                return Result.Fail( ResultErrorFactory.External( "Request message was null.", "API_REQUEST_BUILD_ERROR" ) );
 
             message.Headers.Accept.Clear();
             message.Headers.Accept.Add( new MediaTypeWithQualityHeaderValue( "application/json" ) );
             message.Headers.Accept.Add( new MediaTypeWithQualityHeaderValue( "application/problem+json" ) );
-            if(!string.IsNullOrWhiteSpace( request.ETag )) message.Headers.TryAddWithoutValidation( "If-None-Match", request.ETag );
+            if(!string.IsNullOrWhiteSpace( request.ETag ))
+                message.Headers.TryAddWithoutValidation( "If-None-Match", request.ETag );
 
-            using var response = await _httpClient
+            using var response = await _apiClientContext.HttpClient
                 .SendAsync( message, HttpCompletionOption.ResponseHeadersRead, cancellationToken )
-                .ConfigureAwait(false);
+                .ConfigureAwait( false );
 
             if(response.StatusCode == HttpStatusCode.NotModified) {
                 var cached = new ApiDownloadFilePathsResult( Array.Empty<ApiDownloadFilePathsItem>(), response.Headers.ETag?.Tag );
                 return Result.Ok( cached );
             }
 
-            var ensureResult = await EnsureSuccessStatusCodeAsync( response, cancellationToken ).ConfigureAwait(false);
+            var ensureResult = await EnsureSuccessStatusCodeAsync( response, cancellationToken ).ConfigureAwait( false );
             if(ensureResult.IsFailed)
                 return Result.Fail( ensureResult.Errors );
 
             var payloadResponse = await response.Content
-                .ReadFromJsonAsync<DownloadFilePathsResponse>( SerializerOptions, cancellationToken )
-                .ConfigureAwait(false);
+                .ReadFromJsonAsync<DownloadFilePathsPostResponse>( SerializerOptions, cancellationToken )
+                .ConfigureAwait( false );
 
             if(payloadResponse is null)
                 return Result.Fail( ResultErrorFactory.External( "Response body was null.", "API_EMPTY_RESPONSE" ) );
 
             var items = payloadResponse.Files?
-                .Where(file => file is not null && !string.IsNullOrWhiteSpace( file.Url ) && !string.IsNullOrWhiteSpace( file.Path ))
-                .Select(file => new ApiDownloadFilePathsItem( file.Url!, file.Path! ))
+                .Where( file => file is not null && !string.IsNullOrWhiteSpace( file.Url ) && !string.IsNullOrWhiteSpace( file.Path ) )
+                .Select( file => new ApiDownloadFilePathsItem( file.Url!, file.Path! ) )
                 .ToArray()
                 ?? [];
 
-            var etag = response.Headers.ETag?.Tag ?? payloadResponse.ETag;
+            var etag = response.Headers.ETag?.Tag ?? payloadResponse.Etag;
             var result = new ApiDownloadFilePathsResult( items, etag );
 
             return Result.Ok( result );
@@ -218,46 +251,69 @@ public class ApiService( HttpClient? httpClient = null ) : IApiService {
 
         try {
             var files = (request.Files ?? Array.Empty<ApiPullRequestFile>())
-                .Where(file => file is not null && !string.IsNullOrWhiteSpace(file.Path))
-                .Select(ToFilePayload)
-                .Where(payload => payload is not null)
-                .Select(payload => payload!)
-                .ToArray();
+                .Where( file => file is not null && !string.IsNullOrWhiteSpace( file.Path ) )
+                .Select( ToFilePayload )
+                .Where( payload => payload is not null )
+                .Select( payload => payload! )
+                .ToList();
 
-            var payload = new CreatePrRequest(
-                request.BranchName,
-                request.CommitMessage,
-                request.PrTitle,
-                request.PrBody,
-                files
+            var requestInfo = _apiClientContext.ApiClient.CreatePr.ToPostRequestInformation(
+                new CreatePrPostRequestBody
+                {
+                    BranchName = request.BranchName,
+                    CommitMessage = request.CommitMessage,
+                    PrTitle = request.PrTitle,
+                    PrBody = request.PrBody,
+                    Files = files,
+                }
             );
 
-            using var response = await _httpClient
-                .PostAsJsonAsync("create-pr", payload, SerializerOptions, cancellationToken)
-                .ConfigureAwait(false);
+            using var message = await _apiClientContext.RequestAdapter
+                .ConvertToNativeRequestAsync<HttpRequestMessage>( requestInfo, cancellationToken )
+                .ConfigureAwait( false );
+            if(message is null)
+                return Result.Fail( ResultErrorFactory.External( "Request message was null.", "API_REQUEST_BUILD_ERROR" ) );
+
+            using var response = await _apiClientContext.HttpClient
+                .SendAsync( message, HttpCompletionOption.ResponseHeadersRead, cancellationToken )
+                .ConfigureAwait( false );
 
             if(!response.IsSuccessStatusCode)
                 return Result.Fail( ResultErrorFactory.External( $"HTTP {(int)response.StatusCode}: {response.ReasonPhrase}", "API_HTTP_ERROR" ) );
 
             var result = await response.Content
-                .ReadFromJsonAsync<CreatePrResponse>(SerializerOptions, cancellationToken)
-                .ConfigureAwait(false);
+                .ReadFromJsonAsync<CreatePrPostResponse>( SerializerOptions, cancellationToken )
+                .ConfigureAwait( false );
 
-            if(result is null) return Result.Fail( ResultErrorFactory.External( "Response body was null.", "API_EMPTY_RESPONSE" ) );
+            if(result is null)
+                return Result.Fail( ResultErrorFactory.External( "Response body was null.", "API_EMPTY_RESPONSE" ) );
 
             var entries = result.Data?
-                .Select(ToCreatePrEntry)
-                .Where(entry => entry is not null)
-                .Select(entry => entry!)
+                .Select( ToCreatePrEntry )
+                .Where( entry => entry is not null )
+                .Select( entry => entry! )
                 .ToArray()
                 ?? [];
 
-            var outcome = new ApiCreatePullRequestOutcome(result.Success ?? false, result.Message, entries);
+            var outcome = new ApiCreatePullRequestOutcome( result.Success ?? false, result.Message, entries );
             return Result.Ok( outcome );
         }
         catch(Exception ex) {
             return Result.Fail( ResultErrorFactory.Unexpected( ex, "API_CREATE_PR_EXCEPTION" ) );
         }
+    }
+
+    /// <summary>
+    /// 渡された <see cref="HttpClient"/> と Kiota クライアント群を初期化する。
+    /// </summary>
+    /// <param name="httpClient">外部から供給される <see cref="HttpClient"/>。任意。</param>
+    /// <returns>API呼び出しに必要な依存一式を返す。</returns>
+    private static ApiClientContext InitializeApiClientContext( HttpClient? httpClient ) {
+        var client = InitializeClient( httpClient );
+        var requestAdapter = new HttpClientRequestAdapter( new AnonymousAuthenticationProvider(), httpClient: client );
+        requestAdapter.BaseUrl = client.BaseAddress?.AbsoluteUri?.TrimEnd( '/' ) ?? DefaultBaseUrl.TrimEnd( '/' );
+        var apiClient = new DcsApiClient( requestAdapter );
+        return new ApiClientContext( client, requestAdapter, apiClient );
     }
 
     /// <summary>
@@ -285,9 +341,9 @@ public class ApiService( HttpClient? httpClient = null ) : IApiService {
             return Result.Fail( ResultErrorFactory.Validation( "Paths には少なくとも1つの値が含まれている必要があります。", "API_PATHS_REQUIRED" ) );
 
         var sanitizedPaths = paths
-            .Select(path => path?.Trim())
-            .Where(path => !string.IsNullOrWhiteSpace( path ))
-            .Select(path => path!)
+            .Select( path => path?.Trim() )
+            .Where( path => !string.IsNullOrWhiteSpace( path ) )
+            .Select( path => path! )
             .ToArray();
 
         if(sanitizedPaths.Length == 0)
@@ -309,7 +365,7 @@ public class ApiService( HttpClient? httpClient = null ) : IApiService {
 
         var reason = response.ReasonPhrase ?? $"HTTP {(int)response.StatusCode}";
         if(response.Content is not null) {
-            var body = await response.Content.ReadAsStringAsync( cancellationToken ).ConfigureAwait(false);
+            var body = await response.Content.ReadAsStringAsync( cancellationToken ).ConfigureAwait( false );
             if(!string.IsNullOrWhiteSpace( body ))
                 reason = $"{reason} - {body}";
         }
@@ -339,13 +395,28 @@ public class ApiService( HttpClient? httpClient = null ) : IApiService {
     /// <summary>API用のファイル変更ペイロードに変換する。</summary>
     /// <param name="file">PRに含めるファイル情報。</param>
     /// <returns>変換結果。対応外の操作は null。</returns>
-    private static CreatePrFilePayload? ToFilePayload( ApiPullRequestFile file ) {
+    private static CreatePrPostRequestBody.CreatePrPostRequestBody_files? ToFilePayload( ApiPullRequestFile file ) {
         ArgumentNullException.ThrowIfNull( file );
 
         return file.Operation switch
         {
-            ApiPullRequestFileOperation.Upsert => new CreatePrFilePayload( "upsert", file.Path, file.Content ),
-            ApiPullRequestFileOperation.Delete => new CreatePrFilePayload( "delete", file.Path, null ),
+            ApiPullRequestFileOperation.Upsert => new CreatePrPostRequestBody.CreatePrPostRequestBody_files
+            {
+                CreatePrPostRequestBodyFilesMember1 = new CreatePrPostRequestBody_filesMember1
+                {
+                    Operation = CreatePrPostRequestBody_filesMember1_operation.Upsert,
+                    Path = file.Path,
+                    Content = file.Content,
+                },
+            },
+            ApiPullRequestFileOperation.Delete => new CreatePrPostRequestBody.CreatePrPostRequestBody_files
+            {
+                CreatePrPostRequestBodyFilesMember2 = new CreatePrPostRequestBody_filesMember2
+                {
+                    Operation = CreatePrPostRequestBody_filesMember2_operation.Delete,
+                    Path = file.Path,
+                },
+            },
             _ => null,
         };
     }
@@ -353,7 +424,7 @@ public class ApiService( HttpClient? httpClient = null ) : IApiService {
     /// <summary>PR作成レスポンスのエントリをアプリ内モデルに変換する。</summary>
     /// <param name="payload">レスポンスの生データ。</param>
     /// <returns>アプリ内エントリ。<paramref name="payload"/> が null の場合は null。</returns>
-    private static ApiCreatePullRequestEntry? ToCreatePrEntry( CreatePrEntryPayload? payload ) {
+    private static ApiCreatePullRequestEntry? ToCreatePrEntry( CreatePrPostResponse_data? payload ) {
         if(payload is null) return null;
 
         Uri? prUrl = null;
@@ -394,83 +465,9 @@ public class ApiService( HttpClient? httpClient = null ) : IApiService {
         [property: JsonPropertyName( "type" )] string? Type
     );
 
-    /// <summary>複数パスのZIPダウンロード要求ペイロード。</summary>
-    /// <param name="Paths">ダウンロード対象パス一覧。</param>
-    private sealed record DownloadFilesRequest(
-        [property: JsonPropertyName( "paths" )] IReadOnlyList<string> Paths
-    );
-
-    /// <summary>複数パスのダウンロードリンク取得要求ペイロード。</summary>
-    /// <param name="Paths">リンク生成対象パス一覧。</param>
-    private sealed record DownloadFilePathsRequest(
-        [property: JsonPropertyName( "paths" )] IReadOnlyList<string> Paths
-    );
-
-    /// <summary>複数パスのダウンロードリンク取得応答ペイロード。</summary>
-    /// <param name="Files">生成されたリンク一覧。</param>
-    /// <param name="ETag">応答のETag。</param>
-    /// <param name="GeneratedAt">生成時刻。</param>
-    /// <param name="Version">スキーマのバージョン。</param>
-    private sealed record DownloadFilePathsResponse(
-        [property: JsonPropertyName( "files" )] List<DownloadFilePathsResponseFile>? Files,
-        [property: JsonPropertyName( "etag" )] string? ETag,
-        [property: JsonPropertyName( "generatedAt" )] string? GeneratedAt,
-        [property: JsonPropertyName( "version" )] double? Version
-    );
-
-    /// <summary>ダウンロードリンク応答内の1ファイルを表現する。</summary>
-    /// <param name="Url">生成されたダウンロードURL。</param>
-    /// <param name="Path">リポジトリ上のパス。</param>
-    private sealed record DownloadFilePathsResponseFile(
-        [property: JsonPropertyName( "url" )] string? Url,
-        [property: JsonPropertyName( "path" )] string? Path
-    );
-
-    /// <summary>PR作成要求ペイロード。</summary>
-    /// <param name="BranchName">作成先ブランチ名。</param>
-    /// <param name="CommitMessage">コミットメッセージ。</param>
-    /// <param name="PrTitle">PRタイトル。</param>
-    /// <param name="PrBody">PR本文。</param>
-    /// <param name="Files">変更ファイル一覧。</param>
-    private sealed record CreatePrRequest(
-        [property: JsonPropertyName( "branchName" )] string BranchName,
-        [property: JsonPropertyName( "commitMessage" )] string CommitMessage,
-        [property: JsonPropertyName( "prTitle" )] string PrTitle,
-        [property: JsonPropertyName( "prBody" )] string PrBody,
-        [property: JsonPropertyName( "files" )] IReadOnlyList<CreatePrFilePayload> Files
-    );
-
-    /// <summary>PR用ファイル変更ペイロード。</summary>
-    /// <param name="Operation">操作種別。"upsert" または "delete"。</param>
-    /// <param name="Path">対象パス。</param>
-    /// <param name="Content">ファイル内容（<c>upsert</c> のみ）。</param>
-    private sealed record CreatePrFilePayload(
-        [property: JsonPropertyName( "operation" )] string Operation,
-        [property: JsonPropertyName( "path" )] string Path,
-        [property: JsonPropertyName( "content" ), JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )] string? Content
-    );
-
-    /// <summary>PR作成応答ペイロード。</summary>
-    /// <param name="Success">処理成否。</param>
-    /// <param name="Message">メッセージ。</param>
-    /// <param name="Data">作成されたPRやコミットの一覧。</param>
-    private sealed record CreatePrResponse(
-        [property: JsonPropertyName( "success" )] bool? Success,
-        [property: JsonPropertyName( "message" )] string? Message,
-        [property: JsonPropertyName( "data" )] List<CreatePrEntryPayload>? Data
-    );
-
-    /// <summary>PR作成結果の1エントリ。</summary>
-    /// <param name="BranchName">ブランチ名。</param>
-    /// <param name="CommitSha">コミットSHA。</param>
-    /// <param name="PrNumber">PR番号。</param>
-    /// <param name="PrUrl">PRのURL。</param>
-    /// <param name="Note">付加情報。</param>
-    private sealed record CreatePrEntryPayload(
-        [property: JsonPropertyName( "branchName" )] string? BranchName,
-        [property: JsonPropertyName( "commitSha" )] string? CommitSha,
-        [property: JsonPropertyName( "prNumber" )] int? PrNumber,
-        [property: JsonPropertyName( "prUrl" )] string? PrUrl,
-        [property: JsonPropertyName( "note" )] string? Note
-    );
+    /// <summary>APIクライアント依存をまとめる。</summary>
+    /// <param name="HttpClient">HTTP送信用クライアント。</param>
+    /// <param name="RequestAdapter">KiotaのHTTP変換アダプター。</param>
+    /// <param name="ApiClient">Kiota生成のAPIクライアント。</param>
+    private sealed record ApiClientContext( HttpClient HttpClient, HttpClientRequestAdapter RequestAdapter, DcsApiClient ApiClient );
 }

--- a/src/DcsTranslationTool.Infrastructure/packages.lock.json
+++ b/src/DcsTranslationTool.Infrastructure/packages.lock.json
@@ -21,6 +21,15 @@
           "Std.UriTemplate": "2.0.8"
         }
       },
+      "Microsoft.Kiota.Http.HttpClientLibrary": {
+        "type": "Direct",
+        "requested": "[1.21.2, )",
+        "resolved": "1.21.2",
+        "contentHash": "rIzUUPjPaCRA7gIsw3vi9Vd8eWjR1UlwBZ9bbuUsgV3Mt4DShbh72W0uZma5UX18HBlfzEXnahyCvPCHAmfTDg==",
+        "dependencies": {
+          "Microsoft.Kiota.Abstractions": "1.21.2"
+        }
+      },
       "Microsoft.Kiota.Serialization.Form": {
         "type": "Direct",
         "requested": "[1.21.2, )",

--- a/src/DcsTranslationTool.Presentation.Wpf/packages.lock.json
+++ b/src/DcsTranslationTool.Presentation.Wpf/packages.lock.json
@@ -59,6 +59,14 @@
           "Std.UriTemplate": "2.0.8"
         }
       },
+      "Microsoft.Kiota.Http.HttpClientLibrary": {
+        "type": "Transitive",
+        "resolved": "1.21.2",
+        "contentHash": "rIzUUPjPaCRA7gIsw3vi9Vd8eWjR1UlwBZ9bbuUsgV3Mt4DShbh72W0uZma5UX18HBlfzEXnahyCvPCHAmfTDg==",
+        "dependencies": {
+          "Microsoft.Kiota.Abstractions": "1.21.2"
+        }
+      },
       "Microsoft.Kiota.Serialization.Form": {
         "type": "Transitive",
         "resolved": "1.21.2",
@@ -152,6 +160,7 @@
           "DcsTranslationTool.Shared": "[1.0.0, )",
           "FluentResults": "[4.0.0, )",
           "Microsoft.Kiota.Abstractions": "[1.21.2, )",
+          "Microsoft.Kiota.Http.HttpClientLibrary": "[1.21.2, )",
           "Microsoft.Kiota.Serialization.Form": "[1.21.2, )",
           "Microsoft.Kiota.Serialization.Json": "[1.21.0, )",
           "Microsoft.Kiota.Serialization.Multipart": "[1.21.0, )",

--- a/tests/DcsTranslationTool.Composition.Tests/packages.lock.json
+++ b/tests/DcsTranslationTool.Composition.Tests/packages.lock.json
@@ -109,6 +109,14 @@
           "Std.UriTemplate": "2.0.8"
         }
       },
+      "Microsoft.Kiota.Http.HttpClientLibrary": {
+        "type": "Transitive",
+        "resolved": "1.21.2",
+        "contentHash": "rIzUUPjPaCRA7gIsw3vi9Vd8eWjR1UlwBZ9bbuUsgV3Mt4DShbh72W0uZma5UX18HBlfzEXnahyCvPCHAmfTDg==",
+        "dependencies": {
+          "Microsoft.Kiota.Abstractions": "1.21.2"
+        }
+      },
       "Microsoft.Kiota.Serialization.Form": {
         "type": "Transitive",
         "resolved": "1.21.2",
@@ -372,6 +380,7 @@
           "DcsTranslationTool.Shared": "[1.0.0, )",
           "FluentResults": "[4.0.0, )",
           "Microsoft.Kiota.Abstractions": "[1.21.2, )",
+          "Microsoft.Kiota.Http.HttpClientLibrary": "[1.21.2, )",
           "Microsoft.Kiota.Serialization.Form": "[1.21.2, )",
           "Microsoft.Kiota.Serialization.Json": "[1.21.0, )",
           "Microsoft.Kiota.Serialization.Multipart": "[1.21.0, )",

--- a/tests/DcsTranslationTool.Infrastructure.Tests/packages.lock.json
+++ b/tests/DcsTranslationTool.Infrastructure.Tests/packages.lock.json
@@ -95,6 +95,14 @@
           "Std.UriTemplate": "2.0.8"
         }
       },
+      "Microsoft.Kiota.Http.HttpClientLibrary": {
+        "type": "Transitive",
+        "resolved": "1.21.2",
+        "contentHash": "rIzUUPjPaCRA7gIsw3vi9Vd8eWjR1UlwBZ9bbuUsgV3Mt4DShbh72W0uZma5UX18HBlfzEXnahyCvPCHAmfTDg==",
+        "dependencies": {
+          "Microsoft.Kiota.Abstractions": "1.21.2"
+        }
+      },
       "Microsoft.Kiota.Serialization.Form": {
         "type": "Transitive",
         "resolved": "1.21.2",
@@ -345,6 +353,7 @@
           "DcsTranslationTool.Shared": "[1.0.0, )",
           "FluentResults": "[4.0.0, )",
           "Microsoft.Kiota.Abstractions": "[1.21.2, )",
+          "Microsoft.Kiota.Http.HttpClientLibrary": "[1.21.2, )",
           "Microsoft.Kiota.Serialization.Form": "[1.21.2, )",
           "Microsoft.Kiota.Serialization.Json": "[1.21.0, )",
           "Microsoft.Kiota.Serialization.Multipart": "[1.21.0, )",

--- a/tests/DcsTranslationTool.Presentation.Wpf.Tests/packages.lock.json
+++ b/tests/DcsTranslationTool.Presentation.Wpf.Tests/packages.lock.json
@@ -132,6 +132,14 @@
           "Std.UriTemplate": "2.0.8"
         }
       },
+      "Microsoft.Kiota.Http.HttpClientLibrary": {
+        "type": "Transitive",
+        "resolved": "1.21.2",
+        "contentHash": "rIzUUPjPaCRA7gIsw3vi9Vd8eWjR1UlwBZ9bbuUsgV3Mt4DShbh72W0uZma5UX18HBlfzEXnahyCvPCHAmfTDg==",
+        "dependencies": {
+          "Microsoft.Kiota.Abstractions": "1.21.2"
+        }
+      },
       "Microsoft.Kiota.Serialization.Form": {
         "type": "Transitive",
         "resolved": "1.21.2",
@@ -395,6 +403,7 @@
           "DcsTranslationTool.Shared": "[1.0.0, )",
           "FluentResults": "[4.0.0, )",
           "Microsoft.Kiota.Abstractions": "[1.21.2, )",
+          "Microsoft.Kiota.Http.HttpClientLibrary": "[1.21.2, )",
           "Microsoft.Kiota.Serialization.Form": "[1.21.2, )",
           "Microsoft.Kiota.Serialization.Json": "[1.21.0, )",
           "Microsoft.Kiota.Serialization.Multipart": "[1.21.0, )",


### PR DESCRIPTION
## 📌 概要

<!-- このPRの目的・背景を簡潔に書いてください -->
Kiota 生成コードと手書き `ApiService` の責務重複を解消し、Infrastructure 層の API クライアント実装方針を「Kiota 生成クライアント採用」に一本化する。
あわせて運用時の判断基準がぶれないよう、README に実装方針と更新手順を明記する。

## 🛠 変更内容

<!-- このPRで加えた変更をリストアップしてください -->
- `src/DcsTranslationTool.Infrastructure/Services/ApiService.cs`
  - `download-files` / `download-file-paths` / `create-pr` のリクエスト生成を Kiota 生成 `RequestBuilder` / モデル利用へ統一した。
  - `ApiService` の責務を「オーケストレーション + アプリ契約への変換 + 共通エラー整形」に整理した。
  - 既存互換として ETag(304) 処理、HTTP 失敗時エラーコード(`API_HTTP_ERROR`)を維持した。
- `src/DcsTranslationTool.Infrastructure/DcsTranslationTool.Infrastructure.csproj`
  - Kiota 実行アダプターとして `Microsoft.Kiota.Http.HttpClientLibrary` を追加した。
- `README.md`
  - 「API クライアント実装方針」セクションを追加し、採用方針 / 更新手順 / 変更時の判断基準を追記した。
- 依存更新に伴う lock 更新
  - `src/DcsTranslationTool.Infrastructure/packages.lock.json`
  - `src/DcsTranslationTool.Composition/packages.lock.json`
  - `src/DcsTranslationTool.Presentation.Wpf/packages.lock.json`
  - `tests/DcsTranslationTool.Infrastructure.Tests/packages.lock.json`
  - `tests/DcsTranslationTool.Composition.Tests/packages.lock.json`
  - `tests/DcsTranslationTool.Presentation.Wpf.Tests/packages.lock.json`

## 留意点

<!-- このPRを使用するうえで注意すべきことをリストアップしてください。 -->
<!-- 必要がなければ N/A としてください -->
- `ApiService` は Kiota の生成 `RequestBuilder` を利用してリクエストを構築するため、API 仕様変更時は先に生成コードの更新が必要となる。
- `download-files` / `download-file-paths` は 304 応答を扱うため、引き続き `HttpClient.SendAsync` によるステータス判定を `ApiService` 側で実施している。
- 確認済み: `dotnet test tests/DcsTranslationTool.Infrastructure.Tests/DcsTranslationTool.Infrastructure.Tests.csproj -c Release --no-restore`（107件成功）、`dotnet build -c Release --no-restore`（成功）。

Closes #59 