### PR TITLE
feat(update): 起動時のGitHub Releases更新確認と通知機能を追加

### DIFF
--- a/src/DcsTranslationTool.Application/Interfaces/IUpdateCheckService.cs
+++ b/src/DcsTranslationTool.Application/Interfaces/IUpdateCheckService.cs
@@ -1,0 +1,15 @@
+using DcsTranslationTool.Application.Models;
+
+namespace DcsTranslationTool.Application.Interfaces;
+
+/// <summary>
+/// アプリケーション更新確認を提供するサービス契約とする。
+/// </summary>
+public interface IUpdateCheckService {
+    /// <summary>
+    /// 最新リリースを確認して更新可否を返す。
+    /// </summary>
+    /// <param name="cancellationToken">キャンセル通知を受け取る。</param>
+    /// <returns>更新確認結果を返す。</returns>
+    Task<UpdateCheckResult> CheckForUpdateAsync( CancellationToken cancellationToken = default );
+}

--- a/src/DcsTranslationTool.Application/Models/UpdateCheckResult.cs
+++ b/src/DcsTranslationTool.Application/Models/UpdateCheckResult.cs
@@ -1,0 +1,18 @@
+namespace DcsTranslationTool.Application.Models;
+
+/// <summary>
+/// アプリケーション更新確認結果を表す。
+/// </summary>
+/// <param name="IsUpdateAvailable">更新が利用可能かを示す。</param>
+/// <param name="LatestVersionLabel">通知表示用の最新バージョン文字列を保持する。</param>
+/// <param name="ReleaseUrl">更新先のリリース URL を保持する。</param>
+public sealed record UpdateCheckResult(
+    bool IsUpdateAvailable,
+    string? LatestVersionLabel,
+    string? ReleaseUrl
+) {
+    /// <summary>
+    /// 更新なし結果を返す。
+    /// </summary>
+    public static UpdateCheckResult NoUpdate { get; } = new( false, null, null );
+}

--- a/src/DcsTranslationTool.Composition/CompositionRegistration.cs
+++ b/src/DcsTranslationTool.Composition/CompositionRegistration.cs
@@ -43,6 +43,7 @@ public static class CompositionRegistration {
         c.Singleton<IEnvironmentProvider, EnvironmentProvider>();
         c.Singleton<IProcessLauncher, ProcessLauncher>();
         c.Singleton<ISystemService, SystemService>();
+        c.Singleton<IUpdateCheckService, UpdateCheckService>();
     }
 
     /// <summary>

--- a/src/DcsTranslationTool.Infrastructure/Services/UpdateCheckService.cs
+++ b/src/DcsTranslationTool.Infrastructure/Services/UpdateCheckService.cs
@@ -1,0 +1,140 @@
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json.Serialization;
+
+using DcsTranslationTool.Application.Interfaces;
+using DcsTranslationTool.Application.Models;
+using DcsTranslationTool.Infrastructure.Interfaces;
+using DcsTranslationTool.Shared.Constants;
+
+namespace DcsTranslationTool.Infrastructure.Services;
+
+/// <summary>
+/// GitHub Releases API を利用して更新確認を提供するサービスとする。
+/// </summary>
+/// <param name="applicationInfoService">ローカルアプリケーション情報サービスを受け取る。</param>
+/// <param name="logger">ロギングサービスを受け取る。</param>
+/// <param name="httpClient">外部から注入する HTTP クライアントを受け取る。</param>
+public sealed class UpdateCheckService(
+    IApplicationInfoService applicationInfoService,
+    ILoggingService logger,
+    HttpClient? httpClient = null
+) : IUpdateCheckService {
+    private const string GitHubApiBaseUrl = "https://api.github.com/";
+    private const string GitHubMediaType = "application/vnd.github+json";
+    private const string UserAgent = "DCS-Translation-Tool";
+
+    private readonly HttpClient _httpClient = InitializeHttpClient( httpClient );
+
+    /// <inheritdoc />
+    public async Task<UpdateCheckResult> CheckForUpdateAsync( CancellationToken cancellationToken = default ) {
+        var currentVersion = NormalizeVersion( applicationInfoService.GetVersion() );
+        var requestUri = $"repos/{ApplicationRepository.Owner}/{ApplicationRepository.Repo}/releases/latest";
+
+        try {
+            using var request = new HttpRequestMessage( HttpMethod.Get, requestUri );
+            request.Headers.Accept.Add( new MediaTypeWithQualityHeaderValue( GitHubMediaType ) );
+
+            using var response = await this._httpClient.SendAsync( request, cancellationToken ).ConfigureAwait( false );
+            if(!response.IsSuccessStatusCode) {
+                logger.Warn( $"更新確認 API 呼び出しに失敗した。StatusCode={(int)response.StatusCode}, Reason={response.ReasonPhrase}" );
+                return UpdateCheckResult.NoUpdate;
+            }
+
+            var payload = await response.Content.ReadFromJsonAsync<GitHubReleasePayload>( cancellationToken ).ConfigureAwait( false );
+            if(payload is null || string.IsNullOrWhiteSpace( payload.TagName )) {
+                logger.Warn( "更新確認 API のレスポンスが不正なため通知を行わない。" );
+                return UpdateCheckResult.NoUpdate;
+            }
+
+            if(payload is { Prerelease: true } or { Draft: true }) {
+                logger.Info( $"プレリリースまたはドラフトを検出したため通知対象外とした。Tag={payload.TagName}" );
+                return UpdateCheckResult.NoUpdate;
+            }
+
+            if(!TryNormalizeVersion( payload.TagName, out var latestVersion )) {
+                logger.Warn( $"最新リリースのタグ解析に失敗した。Tag={payload.TagName}" );
+                return UpdateCheckResult.NoUpdate;
+            }
+
+            if(latestVersion <= currentVersion) {
+                logger.Info( $"更新不要と判定した。Current={currentVersion}, Latest={latestVersion}" );
+                return UpdateCheckResult.NoUpdate;
+            }
+
+            var latestVersionLabel = NormalizeTagLabel( payload.TagName );
+            var releaseUrl = ResolveReleaseUrl( payload.HtmlUrl, payload.TagName );
+            logger.Info( $"更新を検出した。Current={currentVersion}, Latest={latestVersionLabel}" );
+            return new UpdateCheckResult( true, latestVersionLabel, releaseUrl );
+        }
+        catch(TaskCanceledException ex) when(!cancellationToken.IsCancellationRequested) {
+            logger.Warn( "更新確認 API 呼び出しがタイムアウトしたため通知を行わない。", ex );
+            return UpdateCheckResult.NoUpdate;
+        }
+        catch(HttpRequestException ex) {
+            logger.Warn( "更新確認 API 呼び出しで通信エラーが発生したため通知を行わない。", ex );
+            return UpdateCheckResult.NoUpdate;
+        }
+        catch(Exception ex) {
+            logger.Warn( "更新確認処理で予期しないエラーが発生したため通知を行わない。", ex );
+            return UpdateCheckResult.NoUpdate;
+        }
+    }
+
+    private static HttpClient InitializeHttpClient( HttpClient? httpClient ) {
+        var client = httpClient ?? new HttpClient();
+        client.BaseAddress ??= new Uri( GitHubApiBaseUrl );
+
+        if(client.DefaultRequestHeaders.UserAgent.Count == 0) {
+            client.DefaultRequestHeaders.UserAgent.Add( new ProductInfoHeaderValue( UserAgent, "1.0" ) );
+        }
+
+        if(client.DefaultRequestHeaders.Accept.All( header => header.MediaType != GitHubMediaType )) {
+            client.DefaultRequestHeaders.Accept.Add( new MediaTypeWithQualityHeaderValue( GitHubMediaType ) );
+        }
+
+        return client;
+    }
+
+    private static string ResolveReleaseUrl( string? htmlUrl, string tagName ) {
+        if(Uri.TryCreate( htmlUrl, UriKind.Absolute, out var releaseUrl )) {
+            return releaseUrl.AbsoluteUri;
+        }
+
+        var trimmedTagName = tagName.Trim();
+        return $"{ApplicationRepository.Url}/releases/tag/{Uri.EscapeDataString( trimmedTagName )}";
+    }
+
+    private static string NormalizeTagLabel( string tagName ) {
+        var trimmed = tagName.Trim();
+        return trimmed.StartsWith( "v", StringComparison.OrdinalIgnoreCase ) ? trimmed : $"v{trimmed}";
+    }
+
+    private static bool TryNormalizeVersion( string rawVersion, out Version version ) {
+        var candidate = rawVersion.Trim();
+        if(candidate.StartsWith( "v", StringComparison.OrdinalIgnoreCase )) {
+            candidate = candidate[1..];
+        }
+
+        if(!Version.TryParse( candidate, out var parsedVersion )) {
+            version = new Version( 0, 0, 0, 0 );
+            return false;
+        }
+
+        version = NormalizeVersion( parsedVersion );
+        return true;
+    }
+
+    private static Version NormalizeVersion( Version version ) {
+        var build = version.Build < 0 ? 0 : version.Build;
+        var revision = version.Revision < 0 ? 0 : version.Revision;
+        return new Version( version.Major, version.Minor, build, revision );
+    }
+
+    private sealed record GitHubReleasePayload(
+        [property: JsonPropertyName( "tag_name" )] string? TagName,
+        [property: JsonPropertyName( "html_url" )] string? HtmlUrl,
+        [property: JsonPropertyName( "draft" )] bool Draft,
+        [property: JsonPropertyName( "prerelease" )] bool Prerelease
+    );
+}

--- a/src/DcsTranslationTool.Resources/Strings.Shared.Designer.cs
+++ b/src/DcsTranslationTool.Resources/Strings.Shared.Designer.cs
@@ -68,5 +68,23 @@ namespace DcsTranslationTool.Resources {
                 return ResourceManager.GetString("AppDisplayName", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   DLページ に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string UpdateActionOpenRelease {
+            get {
+                return ResourceManager.GetString("UpdateActionOpenRelease", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   新しいバージョン {0} が利用可能です に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string UpdateAvailableMessageFormat {
+            get {
+                return ResourceManager.GetString("UpdateAvailableMessageFormat", resourceCulture);
+            }
+        }
     }
 }

--- a/src/DcsTranslationTool.Resources/Strings.Shared.resx
+++ b/src/DcsTranslationTool.Resources/Strings.Shared.resx
@@ -120,4 +120,10 @@
   <data name="AppDisplayName" xml:space="preserve">
     <value>DCS Translation Tool</value>
   </data>
+  <data name="UpdateActionOpenRelease" xml:space="preserve">
+    <value>DLページ</value>
+  </data>
+  <data name="UpdateAvailableMessageFormat" xml:space="preserve">
+    <value>新しいバージョン {0} が利用可能です</value>
+  </data>
 </root>

--- a/src/DcsTranslationTool.Shared/Constants/ApplicationRepository.cs
+++ b/src/DcsTranslationTool.Shared/Constants/ApplicationRepository.cs
@@ -1,0 +1,24 @@
+namespace DcsTranslationTool.Shared.Constants;
+
+/// <summary>
+/// アプリ本体リポジトリに関する固定情報を保持する。
+/// </summary>
+public static class ApplicationRepository {
+    private const string _owner = "5kdn";
+    private const string _repo = "DCS-Translation-Tool";
+
+    /// <summary>
+    /// GitHub リポジトリの所有者名を返す。
+    /// </summary>
+    public static string Owner => _owner;
+
+    /// <summary>
+    /// GitHub リポジトリ名を返す。
+    /// </summary>
+    public static string Repo => _repo;
+
+    /// <summary>
+    /// GitHub リポジトリ URL を返す。
+    /// </summary>
+    public static string Url => $"https://github.com/{Owner}/{Repo}";
+}

--- a/tests/DcsTranslationTool.Composition.Tests/CompositionRegistrationTests.cs
+++ b/tests/DcsTranslationTool.Composition.Tests/CompositionRegistrationTests.cs
@@ -24,6 +24,7 @@ public class CompositionRegistrationTests {
         var appSettingsService = container.GetInstance( typeof( IAppSettingsService ), null );
         var apiService1 = container.GetInstance( typeof( IApiService ), null );
         var apiService2 = container.GetInstance( typeof( IApiService ), null );
+        var updateCheckService = container.GetInstance( typeof( IUpdateCheckService ), null );
         var zipService1 = container.GetInstance( typeof( IZipService ), null );
         var zipService2 = container.GetInstance( typeof( IZipService ), null );
 
@@ -33,6 +34,7 @@ public class CompositionRegistrationTests {
         context.TrackedAppSettings = Assert.IsType<AppSettingsService>( appSettingsService );
         Assert.Same( apiService1, apiService2 );
         Assert.IsType<ApiService>( apiService1 );
+        Assert.IsType<UpdateCheckService>( updateCheckService );
         Assert.Same( zipService1, zipService2 );
         Assert.NotNull( NLogManager.Configuration );
     }

--- a/tests/DcsTranslationTool.Infrastructure.Tests/Services/UpdateCheckServiceTests.cs
+++ b/tests/DcsTranslationTool.Infrastructure.Tests/Services/UpdateCheckServiceTests.cs
@@ -1,0 +1,187 @@
+using System.Net;
+using System.Text;
+
+using DcsTranslationTool.Application.Interfaces;
+using DcsTranslationTool.Infrastructure.Interfaces;
+using DcsTranslationTool.Infrastructure.Services;
+
+using Moq;
+
+namespace DcsTranslationTool.Infrastructure.Tests.Services;
+
+/// <summary>
+/// <see cref="UpdateCheckService"/> の更新判定挙動を検証する。
+/// </summary>
+public sealed class UpdateCheckServiceTests {
+    [Fact]
+    public async Task CheckForUpdateAsyncは最新版が存在する場合に更新ありを返す() {
+        var loggerMock = new Mock<ILoggingService>();
+        var appInfoService = new StubApplicationInfoService( new Version( 1, 3, 1, 0 ) );
+        var httpClient = CreateClient( (request, _) => {
+            Assert.Equal( "/repos/5kdn/DCS-Translation-Tool/releases/latest", request.RequestUri?.AbsolutePath );
+            return Task.FromResult( new HttpResponseMessage( HttpStatusCode.OK )
+            {
+                Content = new StringContent(
+                """
+                {
+                  "tag_name": "v1.4.0",
+                  "html_url": "https://github.com/5kdn/DCS-Translation-Tool/releases/tag/v1.4.0",
+                  "draft": false,
+                  "prerelease": false
+                }
+                """,
+                Encoding.UTF8,
+                "application/json" )
+            } );
+        } );
+
+        var sut = new UpdateCheckService( appInfoService, loggerMock.Object, httpClient );
+
+        var result = await sut.CheckForUpdateAsync( TestContext.Current.CancellationToken );
+
+        Assert.True( result.IsUpdateAvailable );
+        Assert.Equal( "v1.4.0", result.LatestVersionLabel );
+        Assert.Equal( "https://github.com/5kdn/DCS-Translation-Tool/releases/tag/v1.4.0", result.ReleaseUrl );
+    }
+
+    [Fact]
+    public async Task CheckForUpdateAsyncは同一バージョンの場合に更新なしを返す() {
+        var loggerMock = new Mock<ILoggingService>();
+        var appInfoService = new StubApplicationInfoService( new Version( 1, 3, 1, 0 ) );
+        var httpClient = CreateClient( (_, _) => Task.FromResult( new HttpResponseMessage( HttpStatusCode.OK )
+        {
+            Content = new StringContent(
+                """
+                {
+                  "tag_name": "v1.3.1",
+                  "html_url": "https://github.com/5kdn/DCS-Translation-Tool/releases/tag/v1.3.1",
+                  "draft": false,
+                  "prerelease": false
+                }
+                """,
+                Encoding.UTF8,
+                "application/json" )
+        } ) );
+
+        var sut = new UpdateCheckService( appInfoService, loggerMock.Object, httpClient );
+
+        var result = await sut.CheckForUpdateAsync( TestContext.Current.CancellationToken );
+
+        Assert.False( result.IsUpdateAvailable );
+    }
+
+    [Fact]
+    public async Task CheckForUpdateAsyncはタグ形式差異を同一系列として判定する() {
+        var loggerMock = new Mock<ILoggingService>();
+        var appInfoService = new StubApplicationInfoService( new Version( 1, 3, 1, 0 ) );
+        var httpClient = CreateClient( (_, _) => Task.FromResult( new HttpResponseMessage( HttpStatusCode.OK )
+        {
+            Content = new StringContent(
+                """
+                {
+                  "tag_name": "1.3.1",
+                  "html_url": "https://github.com/5kdn/DCS-Translation-Tool/releases/tag/v1.3.1",
+                  "draft": false,
+                  "prerelease": false
+                }
+                """,
+                Encoding.UTF8,
+                "application/json" )
+        } ) );
+
+        var sut = new UpdateCheckService( appInfoService, loggerMock.Object, httpClient );
+
+        var result = await sut.CheckForUpdateAsync( TestContext.Current.CancellationToken );
+
+        Assert.False( result.IsUpdateAvailable );
+    }
+
+    [Fact]
+    public async Task CheckForUpdateAsyncはHttp失敗時に更新なしを返して警告ログを出す() {
+        var loggerMock = new Mock<ILoggingService>();
+        var appInfoService = new StubApplicationInfoService( new Version( 1, 3, 1, 0 ) );
+        var httpClient = CreateClient( (_, _) => Task.FromResult( new HttpResponseMessage( HttpStatusCode.InternalServerError )
+        {
+            ReasonPhrase = "Server Error"
+        } ) );
+
+        var sut = new UpdateCheckService( appInfoService, loggerMock.Object, httpClient );
+
+        var result = await sut.CheckForUpdateAsync( TestContext.Current.CancellationToken );
+
+        Assert.False( result.IsUpdateAvailable );
+        loggerMock.Verify( logger => logger.Warn(
+            It.IsAny<string>(),
+            It.IsAny<Exception?>(),
+            It.IsAny<string?>(),
+            It.IsAny<string?>(),
+            It.IsAny<int>() ), Times.AtLeastOnce );
+    }
+
+    [Fact]
+    public async Task CheckForUpdateAsyncはタイムアウト時に更新なしを返して警告ログを出す() {
+        var loggerMock = new Mock<ILoggingService>();
+        var appInfoService = new StubApplicationInfoService( new Version( 1, 3, 1, 0 ) );
+        var httpClient = CreateClient( (_, _) => throw new TaskCanceledException( "timeout" ) );
+
+        var sut = new UpdateCheckService( appInfoService, loggerMock.Object, httpClient );
+
+        var result = await sut.CheckForUpdateAsync( TestContext.Current.CancellationToken );
+
+        Assert.False( result.IsUpdateAvailable );
+        loggerMock.Verify( logger => logger.Warn(
+            It.IsAny<string>(),
+            It.IsAny<Exception?>(),
+            It.IsAny<string?>(),
+            It.IsAny<string?>(),
+            It.IsAny<int>() ), Times.AtLeastOnce );
+    }
+
+    [Fact]
+    public async Task CheckForUpdateAsyncはタグ解析失敗時に更新なしを返して警告ログを出す() {
+        var loggerMock = new Mock<ILoggingService>();
+        var appInfoService = new StubApplicationInfoService( new Version( 1, 3, 1, 0 ) );
+        var httpClient = CreateClient( (_, _) => Task.FromResult( new HttpResponseMessage( HttpStatusCode.OK )
+        {
+            Content = new StringContent(
+                """
+                {
+                  "tag_name": "not-a-version",
+                  "html_url": "https://github.com/5kdn/DCS-Translation-Tool/releases/tag/not-a-version",
+                  "draft": false,
+                  "prerelease": false
+                }
+                """,
+                Encoding.UTF8,
+                "application/json" )
+        } ) );
+
+        var sut = new UpdateCheckService( appInfoService, loggerMock.Object, httpClient );
+
+        var result = await sut.CheckForUpdateAsync( TestContext.Current.CancellationToken );
+
+        Assert.False( result.IsUpdateAvailable );
+        loggerMock.Verify( logger => logger.Warn(
+            It.IsAny<string>(),
+            It.IsAny<Exception?>(),
+            It.IsAny<string?>(),
+            It.IsAny<string?>(),
+            It.IsAny<int>() ), Times.AtLeastOnce );
+    }
+
+    private static HttpClient CreateClient( Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> responder ) {
+        var handler = new StubHttpMessageHandler( responder );
+        return new HttpClient( handler )
+        {
+            BaseAddress = new Uri( "https://api.github.com/" )
+        };
+    }
+
+    private sealed class StubHttpMessageHandler( Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> responder ) : HttpMessageHandler {
+        protected override Task<HttpResponseMessage> SendAsync( HttpRequestMessage request, CancellationToken cancellationToken ) => responder( request, cancellationToken );
+    }
+
+    private sealed class StubApplicationInfoService( Version version ) : IApplicationInfoService {
+        public Version GetVersion() => version;
+    }
+}

--- a/tests/DcsTranslationTool.Presentation.Wpf.Tests/BootstrapperContainerTests.cs
+++ b/tests/DcsTranslationTool.Presentation.Wpf.Tests/BootstrapperContainerTests.cs
@@ -5,7 +5,6 @@ using Caliburn.Micro;
 
 using DcsTranslationTool.Application.Interfaces;
 using DcsTranslationTool.Composition;
-using DcsTranslationTool.Infrastructure.Interfaces;
 using DcsTranslationTool.Infrastructure.IO;
 using DcsTranslationTool.Infrastructure.Providers;
 using DcsTranslationTool.Infrastructure.Services;
@@ -33,7 +32,7 @@ public sealed class BootstrapperContainerTests {
         } );
     }
 
-    private static Task RunOnStaThreadAsync( System.Action action ) {
+    private static Task<object?> RunOnStaThreadAsync( System.Action action ) {
         var tcs = new TaskCompletionSource<object?>();
         var thread = new Thread( () => {
             try {
@@ -114,6 +113,7 @@ public sealed class BootstrapperContainerTests {
             Assert.IsType<EnvironmentProvider>( Get<IEnvironmentProvider>() );
             Assert.IsType<ProcessLauncher>( Get<IProcessLauncher>() );
             Assert.IsType<SystemService>( Get<ISystemService>() );
+            Assert.IsType<UpdateCheckService>( Get<IUpdateCheckService>() );
             Assert.IsType<ZipService>( Get<IZipService>() );
             Assert.IsType<DialogProvider>( Get<IDialogProvider>() );
             Assert.IsType<DispatcherService>( Get<IDispatcherService>() );


### PR DESCRIPTION
## 📌 概要

<!-- このPRの目的・背景を簡潔に書いてください -->
アプリ起動時に GitHub Releases の最新版を確認し、更新が存在する場合にのみユーザーへ通知できるようにすることを目的とする。手動確認依存を減らし、最新版への追従性を向上する。

## 🛠 変更内容

<!-- このPRで加えた変更をリストアップしてください -->
- `IUpdateCheckService` / `UpdateCheckResult` を追加し、更新確認のアプリケーション契約を定義した。
- `UpdateCheckService` を追加し、GitHub Releases API (`/releases/latest`) で更新判定する処理を実装した。
- `ShellViewModel` に起動時 1 回のみの更新確認フローを追加し、更新時はスナックバー通知と `DLページ` アクションを表示するようにした。
- `ApplicationRepository` 定数を追加し、owner/repo/url を集約した。
- `Strings.Shared.resx` に更新通知文言を追加した。
- DI 登録 (`CompositionRegistration`) を更新し、`IUpdateCheckService` を解決可能にした。
- `UpdateCheckServiceTests`、`ShellViewModelTests`、DI 関連テストを追加・更新した。

## 留意点

<!-- このPRを使用するうえで注意すべきことをリストアップしてください。 -->
<!-- 必要がなければ N/A としてください -->
- GitHub API 応答失敗・タイムアウト・タグ不正時は安全側で「更新なし」扱いとなる。
- 更新通知は起動時のみ実行し、手動更新確認 UI は本PR範囲外とする。
- API 呼び出し回数抑制のキャッシュ戦略は本PRでは未実装である。

Closes #62