### PR TITLE
feat(perf): SHAキャッシュ導入とTree API経路最適化で一覧取得とツリー表示を高速化

### DIFF
--- a/src/DcsTranslationTool.Application/Interfaces/IFileEntryHashCacheService.cs
+++ b/src/DcsTranslationTool.Application/Interfaces/IFileEntryHashCacheService.cs
@@ -1,0 +1,43 @@
+namespace DcsTranslationTool.Application.Interfaces;
+
+/// <summary>
+/// ローカルファイルのハッシュキャッシュを永続化して管理する。
+/// </summary>
+public interface IFileEntryHashCacheService {
+    /// <summary>
+    /// キャッシュの対象ルートを設定して初期化する。
+    /// </summary>
+    /// <param name="rootPath">翻訳ルートの絶対パス。</param>
+    void ConfigureRoot( string rootPath );
+
+    /// <summary>
+    /// 属性一致時にキャッシュ済み SHA1 を取得する。
+    /// </summary>
+    /// <param name="relativePath">ルートからの相対パス。</param>
+    /// <param name="fileSize">ファイルサイズ。</param>
+    /// <param name="lastWriteUtc">最終更新日時（UTC）。</param>
+    /// <param name="sha">取得した SHA1。</param>
+    /// <returns>一致するキャッシュが存在する場合は <see langword="true"/> を返す。</returns>
+    bool TryGetSha( string relativePath, long fileSize, DateTime lastWriteUtc, out string? sha );
+
+    /// <summary>
+    /// ファイル属性と SHA1 をキャッシュへ保存する。
+    /// </summary>
+    /// <param name="relativePath">ルートからの相対パス。</param>
+    /// <param name="fileSize">ファイルサイズ。</param>
+    /// <param name="lastWriteUtc">最終更新日時（UTC）。</param>
+    /// <param name="sha">保存する SHA1。</param>
+    void Upsert( string relativePath, long fileSize, DateTime lastWriteUtc, string? sha );
+
+    /// <summary>
+    /// 指定パスのキャッシュを削除する。
+    /// </summary>
+    /// <param name="relativePath">ルートからの相対パス。</param>
+    void Remove( string relativePath );
+
+    /// <summary>
+    /// 現在存在しないファイルのキャッシュを一括削除する。
+    /// </summary>
+    /// <param name="existingRelativePaths">現在存在する相対パス集合。</param>
+    void Prune( IReadOnlySet<string> existingRelativePaths );
+}

--- a/src/DcsTranslationTool.Composition/CompositionRegistration.cs
+++ b/src/DcsTranslationTool.Composition/CompositionRegistration.cs
@@ -35,7 +35,9 @@ public static class CompositionRegistration {
         var appSettingsService = new AppSettingsService( loggingService, saveDir, fileName );
         c.Instance<IAppSettingsService>( appSettingsService );
 
+        c.Singleton<ITreeHttpClientProvider, TreeHttpClientProvider>();
         c.Singleton<IApiService, ApiService>();
+        c.Singleton<IFileEntryHashCacheService, FileEntryHashCacheService>();
         c.Singleton<IFileContentInspector, FileContentInspector>();
         c.Singleton<IFileEntryService, FileEntryService>();
         c.Singleton<IFileService, FileService>();

--- a/src/DcsTranslationTool.Composition/packages.lock.json
+++ b/src/DcsTranslationTool.Composition/packages.lock.json
@@ -26,6 +26,24 @@
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
       },
+      "Microsoft.Data.Sqlite": {
+        "type": "Transitive",
+        "resolved": "9.0.10",
+        "contentHash": "1waeeEEM/Dp5l2laUByEEWfd6qyI00HExDduhLKGT2kPnHArjIDcMf2z9HIjeLPoR56iBHhvXTfAv1hiH/wAAQ==",
+        "dependencies": {
+          "Microsoft.Data.Sqlite.Core": "9.0.10",
+          "SQLitePCLRaw.bundle_e_sqlite3": "2.1.10",
+          "SQLitePCLRaw.core": "2.1.10"
+        }
+      },
+      "Microsoft.Data.Sqlite.Core": {
+        "type": "Transitive",
+        "resolved": "9.0.10",
+        "contentHash": "tWbN2uzG4uBxxMjcHA3Oa9ecAYjyRTfDwRbgQ7ueyx7eEgyYbBiKADY2rllF8wO3dHUvN+/8fgylwSGMfiCtVg==",
+        "dependencies": {
+          "SQLitePCLRaw.core": "2.1.10"
+        }
+      },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "Transitive",
         "resolved": "2.1.1",
@@ -95,10 +113,45 @@
         "resolved": "6.0.7",
         "contentHash": "16kwDY6+/TCBToyXekpcl5mxprUWuXqltdOK26w44E0rTQTiRCjXv1VVLDtSbgMCR1RirVvr+V/9T+76cwuqnw=="
       },
+      "SQLitePCLRaw.bundle_e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "2.1.10",
+        "contentHash": "UxWuisvZ3uVcVOLJQv7urM/JiQH+v3TmaJc1BLKl5Dxfm/nTzTUrqswCqg/INiYLi61AXnHo1M1JPmPqqLnAdg==",
+        "dependencies": {
+          "SQLitePCLRaw.lib.e_sqlite3": "2.1.10",
+          "SQLitePCLRaw.provider.e_sqlite3": "2.1.10"
+        }
+      },
+      "SQLitePCLRaw.core": {
+        "type": "Transitive",
+        "resolved": "2.1.10",
+        "contentHash": "Ii8JCbC7oiVclaE/mbDEK000EFIJ+ShRPwAvvV89GOZhQ+ZLtlnSWl6ksCNMKu/VGXA4Nfi2B7LhN/QFN9oBcw==",
+        "dependencies": {
+          "System.Memory": "4.5.3"
+        }
+      },
+      "SQLitePCLRaw.lib.e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "2.1.10",
+        "contentHash": "mAr69tDbnf3QJpRy2nJz8Qdpebdil00fvycyByR58Cn9eARvR+UiG2Vzsp+4q1tV3ikwiYIjlXCQFc12GfebbA=="
+      },
+      "SQLitePCLRaw.provider.e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "2.1.10",
+        "contentHash": "uZVTi02C1SxqzgT0HqTWatIbWGb40iIkfc3FpFCpE/r7g6K0PqzDUeefL6P6HPhDtc6BacN3yQysfzP7ks+wSQ==",
+        "dependencies": {
+          "SQLitePCLRaw.core": "2.1.10"
+        }
+      },
       "Std.UriTemplate": {
         "type": "Transitive",
         "resolved": "2.0.8",
         "contentHash": "IAR4gJlLVD4r/FsU/rDb1+9sbB3/tCFVZz5IzlbM2yHoiUisBi5Ek/KXRUF7RcqNARka79EoaOz9INnXvQ/O6w=="
+      },
+      "System.Memory": {
+        "type": "Transitive",
+        "resolved": "4.5.3",
+        "contentHash": "3oDzvc/zzetpTKWMShs1AADwZjQ/36HnsufHRPcOjyRAAMLDlu2iD33MBI2opxnezcVUtXyqDXXjoFMOU9c7SA=="
       },
       "System.Text.Encoding.CodePages": {
         "type": "Transitive",
@@ -136,6 +189,7 @@
           "DcsTranslationTool.Domain": "[1.0.0, )",
           "DcsTranslationTool.Shared": "[1.0.0, )",
           "FluentResults": "[4.0.0, )",
+          "Microsoft.Data.Sqlite": "[9.0.10, )",
           "Microsoft.Kiota.Abstractions": "[1.21.2, )",
           "Microsoft.Kiota.Http.HttpClientLibrary": "[1.21.2, )",
           "Microsoft.Kiota.Serialization.Form": "[1.21.2, )",

--- a/src/DcsTranslationTool.Infrastructure/DcsTranslationTool.Infrastructure.csproj
+++ b/src/DcsTranslationTool.Infrastructure/DcsTranslationTool.Infrastructure.csproj
@@ -14,6 +14,7 @@
         <PackageReference Include="Microsoft.Kiota.Serialization.Json" Version="1.21.0" />
         <PackageReference Include="Microsoft.Kiota.Serialization.Multipart" Version="1.21.0" />
         <PackageReference Include="Microsoft.Kiota.Serialization.Text" Version="1.21.0" />
+        <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.10" />
         <PackageReference Include="NLog" Version="6.0.7" />
         <PackageReference Include="UTF.Unknown" Version="2.6.0" />
     </ItemGroup>

--- a/src/DcsTranslationTool.Infrastructure/Interfaces/ITreeHttpClientProvider.cs
+++ b/src/DcsTranslationTool.Infrastructure/Interfaces/ITreeHttpClientProvider.cs
@@ -1,0 +1,15 @@
+namespace DcsTranslationTool.Infrastructure.Interfaces;
+
+/// <summary>
+/// Tree API のレース呼び出しで利用する HTTP クライアントを供給する。
+/// </summary>
+public interface ITreeHttpClientProvider {
+    /// <summary>既定経路に使う HTTP クライアントを返す。</summary>
+    HttpClient DefaultClient { get; }
+
+    /// <summary>IPv4 優先経路に使う HTTP クライアントを返す。</summary>
+    HttpClient Ipv4PreferredClient { get; }
+
+    /// <summary>IPv4 優先経路が専用クライアントかどうかを返す。</summary>
+    bool IsIpv4PreferredDedicated { get; }
+}

--- a/src/DcsTranslationTool.Infrastructure/Services/ApiService.cs
+++ b/src/DcsTranslationTool.Infrastructure/Services/ApiService.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
@@ -10,7 +11,7 @@ using DcsTranslationTool.Application.Results;
 using DcsTranslationTool.Infrastructure.Http.ApiClient.CreatePr;
 using DcsTranslationTool.Infrastructure.Http.ApiClient.DownloadFilePaths;
 using DcsTranslationTool.Infrastructure.Http.ApiClient.DownloadFiles;
-using DcsTranslationTool.Infrastructure.Http.ApiClient.Health;
+using DcsTranslationTool.Infrastructure.Interfaces;
 using DcsTranslationTool.Shared.Models;
 
 using FluentResults;
@@ -23,8 +24,14 @@ using DcsApiClient = DcsTranslationTool.Infrastructure.Http.ApiClient.ApiClient;
 namespace DcsTranslationTool.Infrastructure.Services;
 
 /// <summary>APIクライアントを操作する</summary>
-public class ApiService( HttpClient? httpClient = null ) : IApiService {
+public class ApiService(
+    ILoggingService loggingService,
+    ITreeHttpClientProvider treeHttpClientProvider
+) : IApiService {
     private const string DefaultBaseUrl = "https://dcs-translation-japanese-cloudflare-worker.dcs-translation-japanese.workers.dev/";
+    private const int TreePrimaryTimeoutSeconds = 10;
+    private const int TreeFallbackTimeoutSeconds = 15;
+    private static readonly TimeSpan Ipv4PreferenceTtl = TimeSpan.FromDays( 1 );
 
     private static readonly JsonSerializerOptions SerializerOptions = new( JsonSerializerDefaults.Web )
     {
@@ -33,7 +40,13 @@ public class ApiService( HttpClient? httpClient = null ) : IApiService {
         Converters = { new JsonStringEnumConverter() },
     };
 
-    private readonly ApiClientContext _apiClientContext = InitializeApiClientContext( httpClient );
+    private readonly ApiClientContext _apiClientContext = InitializeApiClientContext( treeHttpClientProvider.DefaultClient );
+    private readonly ILoggingService _logger = loggingService;
+    private readonly ITreeHttpClientProvider _treeHttpClientProvider = treeHttpClientProvider;
+    private readonly string _ipv4PathPrefix = treeHttpClientProvider.IsIpv4PreferredDedicated ? "ipv4" : "ipv4(shared)";
+    private readonly object _treeRouteGate = new();
+    private TreeRoutePreference _treeRoutePreference = TreeRoutePreference.None;
+    private DateTimeOffset _treeRoutePreferenceUntilUtc = DateTimeOffset.MinValue;
 
     /// <summary>APIのヘルスチェックを実行して結果を返却する</summary>
     public async Task<Result<ApiHealth>> GetHealthAsync( CancellationToken cancellationToken = default ) {
@@ -61,30 +74,119 @@ public class ApiService( HttpClient? httpClient = null ) : IApiService {
 
     /// <summary>APIを呼び出してツリー情報を取得しコレクションとして返却する</summary>
     public async Task<Result<IReadOnlyList<FileEntry>>> GetTreeAsync( CancellationToken cancellationToken = default ) {
-        try {
-            using var resp = await _apiClientContext.HttpClient.GetAsync( "tree", cancellationToken ).ConfigureAwait( false );
-            if(!resp.IsSuccessStatusCode)
-                return Result.Fail( ResultErrorFactory.External( $"HTTP {(int)resp.StatusCode}: {resp.ReasonPhrase}", "API_HTTP_ERROR" ) );
-
-            var payload = await resp.Content.ReadFromJsonAsync<TreeResponse>( SerializerOptions, cancellationToken ).ConfigureAwait( false );
-            if(payload?.Data is not { Count: > 0 } data)
-                return Result.Ok<IReadOnlyList<FileEntry>>( Array.Empty<FileEntry>() );
-
-            var entries = new List<FileEntry>( data.Count );
-            foreach(var item in data) {
-                if(item is null || string.IsNullOrWhiteSpace( item.Path )) continue;
-                var name = ExtractName( item.Path );
-                var isDirectory = IsDirectory( item );
-                entries.Add( new FileEntry( name, item.Path, isDirectory, repoSha: item.Sha ) );
+        var routePreference = GetTreeRoutePreference();
+        if(routePreference == TreeRoutePreference.Ipv4) {
+            var preferredAttempt = await ExecuteTreeRequestAsync(
+                _treeHttpClientProvider.Ipv4PreferredClient,
+                $"{_ipv4PathPrefix}-preferred",
+                TimeSpan.FromSeconds( TreeFallbackTimeoutSeconds ),
+                cancellationToken
+            ).ConfigureAwait( false );
+            LogTreeAttempt( preferredAttempt );
+            if(preferredAttempt.Result.IsSuccess) {
+                LogTreeSummary( preferredAttempt );
+                return preferredAttempt.Result;
             }
-            return Result.Ok<IReadOnlyList<FileEntry>>( entries );
+
+            var fallbackAttempt = await ExecuteTreeRequestAsync(
+                _apiClientContext.HttpClient,
+                "default-retry",
+                TimeSpan.FromSeconds( TreeFallbackTimeoutSeconds ),
+                cancellationToken
+            ).ConfigureAwait( false );
+            LogTreeAttempt( fallbackAttempt );
+            if(fallbackAttempt.Result.IsSuccess) {
+                SetTreeRoutePreference( TreeRoutePreference.Default, "IPv4 優先から default へ復帰したため default 優先を記憶する。" );
+                LogTreeSummary( fallbackAttempt );
+                return fallbackAttempt.Result;
+            }
+
+            LogTreeSummary( fallbackAttempt );
+            return fallbackAttempt.Result;
         }
-        catch(Exception ex) {
-            return Result.Fail( ResultErrorFactory.Unexpected( ex, "API_TREE_EXCEPTION" ) );
+
+        if(routePreference == TreeRoutePreference.Default) {
+            var preferredAttempt = await ExecuteTreeRequestAsync(
+                _apiClientContext.HttpClient,
+                "default-preferred",
+                TimeSpan.FromSeconds( TreePrimaryTimeoutSeconds ),
+                cancellationToken
+            ).ConfigureAwait( false );
+            LogTreeAttempt( preferredAttempt );
+            if(preferredAttempt.Result.IsSuccess) {
+                LogTreeSummary( preferredAttempt );
+                return preferredAttempt.Result;
+            }
+
+            var fallbackAttempt = await ExecuteTreeRequestAsync(
+                _treeHttpClientProvider.Ipv4PreferredClient,
+                $"{_ipv4PathPrefix}-retry",
+                TimeSpan.FromSeconds( TreeFallbackTimeoutSeconds ),
+                cancellationToken
+            ).ConfigureAwait( false );
+            LogTreeAttempt( fallbackAttempt );
+            if(fallbackAttempt.Result.IsSuccess) {
+                SetTreeRoutePreference( TreeRoutePreference.Ipv4, "default 優先から IPv4 へ復帰したため IPv4 優先を記憶する。" );
+                LogTreeSummary( fallbackAttempt );
+                return fallbackAttempt.Result;
+            }
+
+            LogTreeSummary( fallbackAttempt );
+            return fallbackAttempt.Result;
         }
+
+        var racedAttempt = await ExecuteTreeRaceWithoutPreferenceAsync( cancellationToken ).ConfigureAwait( false );
+        LogTreeSummary( racedAttempt );
+        return racedAttempt.Result;
     }
 
-    /// <summary>APIを呼び出して複数ファイルをZIPでダウンロードする</summary>
+    /// <summary>
+    /// 優先経路が未確定のときに default と IPv4 経路を並列実行して先着成功を採用する。
+    /// </summary>
+    /// <param name="cancellationToken">キャンセルトークン。</param>
+    /// <returns>採用した試行結果。</returns>
+    private async Task<TreeRequestAttempt> ExecuteTreeRaceWithoutPreferenceAsync( CancellationToken cancellationToken ) {
+        using var raceCts = CancellationTokenSource.CreateLinkedTokenSource( cancellationToken );
+        var defaultTask = ExecuteTreeRequestAsync(
+            _apiClientContext.HttpClient,
+            "default-race",
+            TimeSpan.FromSeconds( TreePrimaryTimeoutSeconds ),
+            raceCts.Token
+        );
+        var ipv4Task = ExecuteTreeRequestAsync(
+            _treeHttpClientProvider.Ipv4PreferredClient,
+            $"{_ipv4PathPrefix}-race",
+            TimeSpan.FromSeconds( TreeFallbackTimeoutSeconds ),
+            raceCts.Token
+        );
+
+        var firstCompletedTask = await Task.WhenAny( defaultTask, ipv4Task ).ConfigureAwait( false );
+        var firstAttempt = await firstCompletedTask.ConfigureAwait( false );
+        LogTreeAttempt( firstAttempt );
+        if(firstAttempt.Result.IsSuccess) {
+            SetTreeRoutePreferenceByPath( firstAttempt.PathLabel, "初回レースで勝者経路を記憶する。" );
+            var loserTask = ReferenceEquals( firstCompletedTask, defaultTask ) ? ipv4Task : defaultTask;
+            await CancelAndObserveRaceLoserAsync( loserTask, raceCts ).ConfigureAwait( false );
+            _logger.Info( $"GetTreeAsync レース結果。Winner={firstAttempt.PathLabel}" );
+            return firstAttempt;
+        }
+
+        var secondTask = ReferenceEquals( firstCompletedTask, defaultTask ) ? ipv4Task : defaultTask;
+        var secondAttempt = await secondTask.ConfigureAwait( false );
+        LogTreeAttempt( secondAttempt );
+        if(secondAttempt.Result.IsSuccess) {
+            SetTreeRoutePreferenceByPath( secondAttempt.PathLabel, "初回レースで勝者経路を記憶する。" );
+            _logger.Info( $"GetTreeAsync レース結果。Winner={secondAttempt.PathLabel}" );
+            return secondAttempt;
+        }
+
+        _logger.Warn( $"GetTreeAsync レース結果。両経路が失敗した。First={firstAttempt.PathLabel}, Second={secondAttempt.PathLabel}" );
+        return secondAttempt;
+    }
+
+    /// <summary>
+    /// APIを呼び出して複数ファイルをZIPでダウンロードする
+    /// </summary>
     public async Task<Result<ApiDownloadFilesResult>> DownloadFilesAsync(
         ApiDownloadFilesRequest request,
         CancellationToken cancellationToken = default
@@ -128,7 +230,7 @@ public class ApiService( HttpClient? httpClient = null ) : IApiService {
             if(response.StatusCode == HttpStatusCode.NotModified) {
                 var cached = new ApiDownloadFilesResult(
                     sanitizedPaths,
-                    Array.Empty<byte>(),
+                    [],
                     0,
                     null,
                     null,
@@ -210,7 +312,7 @@ public class ApiService( HttpClient? httpClient = null ) : IApiService {
                 .ConfigureAwait( false );
 
             if(response.StatusCode == HttpStatusCode.NotModified) {
-                var cached = new ApiDownloadFilePathsResult( Array.Empty<ApiDownloadFilePathsItem>(), response.Headers.ETag?.Tag );
+                var cached = new ApiDownloadFilePathsResult( [], response.Headers.ETag?.Tag );
                 return Result.Ok( cached );
             }
 
@@ -250,7 +352,7 @@ public class ApiService( HttpClient? httpClient = null ) : IApiService {
         ArgumentNullException.ThrowIfNull( request );
 
         try {
-            var files = (request.Files ?? Array.Empty<ApiPullRequestFile>())
+            var files = (request.Files ?? [])
                 .Where( file => file is not null && !string.IsNullOrWhiteSpace( file.Path ) )
                 .Select( ToFilePayload )
                 .Where( payload => payload is not null )
@@ -306,31 +408,16 @@ public class ApiService( HttpClient? httpClient = null ) : IApiService {
     /// <summary>
     /// 渡された <see cref="HttpClient"/> と Kiota クライアント群を初期化する。
     /// </summary>
-    /// <param name="httpClient">外部から供給される <see cref="HttpClient"/>。任意。</param>
+    /// <param name="httpClient">外部から供給される <see cref="HttpClient"/>。</param>
     /// <returns>API呼び出しに必要な依存一式を返す。</returns>
-    private static ApiClientContext InitializeApiClientContext( HttpClient? httpClient ) {
-        var client = InitializeClient( httpClient );
-        var requestAdapter = new HttpClientRequestAdapter( new AnonymousAuthenticationProvider(), httpClient: client );
-        requestAdapter.BaseUrl = client.BaseAddress?.AbsoluteUri?.TrimEnd( '/' ) ?? DefaultBaseUrl.TrimEnd( '/' );
+    private static ApiClientContext InitializeApiClientContext( HttpClient httpClient ) {
+        var client = httpClient;
+        var requestAdapter = new HttpClientRequestAdapter( new AnonymousAuthenticationProvider(), httpClient: client )
+        {
+            BaseUrl = client.BaseAddress?.AbsoluteUri?.TrimEnd( '/' ) ?? DefaultBaseUrl.TrimEnd( '/' )
+        };
         var apiClient = new DcsApiClient( requestAdapter );
         return new ApiClientContext( client, requestAdapter, apiClient );
-    }
-
-    /// <summary>
-    /// 渡された <see cref="HttpClient"/> を初期化する。未指定時は新規生成する。
-    /// ベースURLとAcceptヘッダーを既定値に整える。
-    /// </summary>
-    /// <param name="httpClient">外部から供給される <see cref="HttpClient"/>。任意。</param>
-    /// <returns>初期化済み <see cref="HttpClient"/>。</returns>
-    private static HttpClient InitializeClient( HttpClient? httpClient ) {
-        var client = httpClient ?? new HttpClient();
-
-        client.BaseAddress ??= new Uri( DefaultBaseUrl );
-
-        if(client.DefaultRequestHeaders.Accept.All( header => header.MediaType != "application/json" ))
-            client.DefaultRequestHeaders.Accept.Add( new MediaTypeWithQualityHeaderValue( "application/json" ) );
-
-        return client;
     }
 
     /// <summary>パス一覧を検証し、空白除去済み配列へ正規化する。</summary>
@@ -391,6 +478,217 @@ public class ApiService( HttpClient? httpClient = null ) : IApiService {
     private static bool IsDirectory( TreeEntryPayload item ) =>
         item.Mode?.Equals( "040000", StringComparison.OrdinalIgnoreCase ) == true
         || item.Type?.Equals( "tree", StringComparison.OrdinalIgnoreCase ) == true;
+
+    /// <summary>
+    /// Tree API を呼び出し、処理結果と内訳を返す。
+    /// </summary>
+    /// <param name="client">呼び出しに使用する HTTP クライアント。</param>
+    /// <param name="pathLabel">呼び出し経路ラベル。</param>
+    /// <param name="timeout">試行タイムアウト。</param>
+    /// <param name="cancellationToken">呼び出し元キャンセルトークン。</param>
+    /// <returns>試行結果。</returns>
+    private static async Task<TreeRequestAttempt> ExecuteTreeRequestAsync(
+        HttpClient client,
+        string pathLabel,
+        TimeSpan timeout,
+        CancellationToken cancellationToken
+    ) {
+        var totalStopwatch = Stopwatch.StartNew();
+        long httpElapsedMs = 0;
+        long deserializeElapsedMs = 0;
+        long mapElapsedMs = 0;
+        var rawCount = 0;
+        var mappedCount = 0;
+        int? statusCode = null;
+
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource( cancellationToken );
+        timeoutCts.CancelAfter( timeout );
+
+        try {
+            var httpStopwatch = Stopwatch.StartNew();
+            using var response = await client.GetAsync( "tree", timeoutCts.Token ).ConfigureAwait( false );
+            httpElapsedMs = httpStopwatch.ElapsedMilliseconds;
+            statusCode = (int)response.StatusCode;
+
+            if(!response.IsSuccessStatusCode) {
+                var error = ResultErrorFactory.External( $"HTTP {(int)response.StatusCode}: {response.ReasonPhrase}", "API_HTTP_ERROR" );
+                return new TreeRequestAttempt(
+                    pathLabel,
+                    Result.Fail<IReadOnlyList<FileEntry>>( error ),
+                    httpElapsedMs,
+                    deserializeElapsedMs,
+                    mapElapsedMs,
+                    totalStopwatch.ElapsedMilliseconds,
+                    rawCount,
+                    mappedCount,
+                    statusCode,
+                    false
+                );
+            }
+
+            var deserializeStopwatch = Stopwatch.StartNew();
+            var payload = await response.Content.ReadFromJsonAsync<TreeResponse>( SerializerOptions, timeoutCts.Token ).ConfigureAwait( false );
+            deserializeElapsedMs = deserializeStopwatch.ElapsedMilliseconds;
+
+            if(payload?.Data is not { Count: > 0 } data) {
+                return new TreeRequestAttempt(
+                    pathLabel,
+                    Result.Ok<IReadOnlyList<FileEntry>>( [] ),
+                    httpElapsedMs,
+                    deserializeElapsedMs,
+                    mapElapsedMs,
+                    totalStopwatch.ElapsedMilliseconds,
+                    rawCount,
+                    mappedCount,
+                    statusCode,
+                    false
+                );
+            }
+
+            rawCount = data.Count;
+            var mapStopwatch = Stopwatch.StartNew();
+            var entries = new List<FileEntry>( data.Count );
+            foreach(var item in data) {
+                if(item is null || string.IsNullOrWhiteSpace( item.Path )) continue;
+                var name = ExtractName( item.Path );
+                var isDirectory = IsDirectory( item );
+                entries.Add( new FileEntry( name, item.Path, isDirectory, repoSha: item.Sha ) );
+            }
+
+            mapElapsedMs = mapStopwatch.ElapsedMilliseconds;
+            mappedCount = entries.Count;
+            return new TreeRequestAttempt(
+                pathLabel,
+                Result.Ok<IReadOnlyList<FileEntry>>( entries ),
+                httpElapsedMs,
+                deserializeElapsedMs,
+                mapElapsedMs,
+                totalStopwatch.ElapsedMilliseconds,
+                rawCount,
+                mappedCount,
+                statusCode,
+                false
+            );
+        }
+        catch(OperationCanceledException) when(!cancellationToken.IsCancellationRequested) {
+            var error = ResultErrorFactory.External( $"Tree API がタイムアウトした。TimeoutMs={(int)timeout.TotalMilliseconds}", "API_TIMEOUT" );
+            return new TreeRequestAttempt(
+                pathLabel,
+                Result.Fail<IReadOnlyList<FileEntry>>( error ),
+                httpElapsedMs,
+                deserializeElapsedMs,
+                mapElapsedMs,
+                totalStopwatch.ElapsedMilliseconds,
+                rawCount,
+                mappedCount,
+                statusCode,
+                true
+            );
+        }
+        catch(Exception ex) {
+            var error = ResultErrorFactory.Unexpected( ex, "API_TREE_EXCEPTION" );
+            return new TreeRequestAttempt(
+                pathLabel,
+                Result.Fail<IReadOnlyList<FileEntry>>( error ),
+                httpElapsedMs,
+                deserializeElapsedMs,
+                mapElapsedMs,
+                totalStopwatch.ElapsedMilliseconds,
+                rawCount,
+                mappedCount,
+                statusCode,
+                false
+            );
+        }
+    }
+
+    /// <summary>
+    /// Tree API の試行結果詳細をデバッグログへ記録する。
+    /// </summary>
+    /// <param name="attempt">記録対象の試行結果。</param>
+    private void LogTreeAttempt( TreeRequestAttempt attempt ) {
+        _logger.Debug(
+            $"GetTreeAsync 内訳。Path={attempt.PathLabel}, StatusCode={attempt.StatusCode?.ToString() ?? "null"}, TimedOut={attempt.TimedOut}, HttpElapsedMs={attempt.HttpElapsedMs}, DeserializeElapsedMs={attempt.DeserializeElapsedMs}, MapElapsedMs={attempt.MapElapsedMs}, RawCount={attempt.RawCount}, MappedCount={attempt.MappedCount}, TotalElapsedMs={attempt.TotalElapsedMs}"
+        );
+    }
+
+    /// <summary>
+    /// Tree API の最終結果を情報ログへ記録する。
+    /// </summary>
+    /// <param name="attempt">最終試行結果。</param>
+    private void LogTreeSummary( TreeRequestAttempt attempt ) {
+        if(attempt.Result.IsSuccess) {
+            _logger.Info( $"GetTreeAsync が完了した。Path={attempt.PathLabel}, Count={attempt.MappedCount}, TotalElapsedMs={attempt.TotalElapsedMs}" );
+            return;
+        }
+
+        var reason = attempt.Result.Errors.Count > 0
+            ? attempt.Result.Errors[0].Message
+            : "unknown";
+        _logger.Info( $"GetTreeAsync が失敗した。Path={attempt.PathLabel}, TotalElapsedMs={attempt.TotalElapsedMs}, Reason={reason}" );
+    }
+
+    /// <summary>
+    /// レース勝者に応じて経路優先を記憶する。
+    /// </summary>
+    /// <param name="pathLabel">勝者パスラベル。</param>
+    /// <param name="reason">切り替え理由。</param>
+    private void SetTreeRoutePreferenceByPath( string pathLabel, string reason ) {
+        if(pathLabel.StartsWith( "ipv4", StringComparison.OrdinalIgnoreCase )) {
+            SetTreeRoutePreference( TreeRoutePreference.Ipv4, reason );
+            return;
+        }
+
+        SetTreeRoutePreference( TreeRoutePreference.Default, reason );
+    }
+
+    /// <summary>
+    /// 経路優先を有効化する。
+    /// </summary>
+    /// <param name="preference">有効化する優先経路。</param>
+    /// <param name="reason">切り替え理由。</param>
+    private void SetTreeRoutePreference( TreeRoutePreference preference, string reason ) {
+        lock(_treeRouteGate) {
+            _treeRoutePreference = preference;
+            _treeRoutePreferenceUntilUtc = DateTimeOffset.UtcNow.Add( Ipv4PreferenceTtl );
+        }
+
+        _logger.Warn( $"{reason} Preference={preference}, 有効期限={_treeRoutePreferenceUntilUtc:O}" );
+    }
+
+    /// <summary>
+    /// レース勝利時に敗者リクエストを取り消して完了を待機する。
+    /// </summary>
+    /// <param name="loserTask">敗者タスク。</param>
+    /// <param name="raceCts">レース用トークンソース。</param>
+    /// <returns>待機タスク。</returns>
+    private async Task CancelAndObserveRaceLoserAsync( Task<TreeRequestAttempt> loserTask, CancellationTokenSource raceCts ) {
+        raceCts.Cancel();
+        try {
+            var loserResult = await loserTask.ConfigureAwait( false );
+            LogTreeAttempt( loserResult );
+        }
+        catch(OperationCanceledException) {
+        }
+        catch(Exception ex) {
+            _logger.Debug( "GetTreeAsync レース敗者の終了待機で例外を補足した。", ex );
+        }
+    }
+
+    /// <summary>
+    /// 現在有効な経路優先を取得する。
+    /// </summary>
+    /// <returns>現在の優先経路。</returns>
+    private TreeRoutePreference GetTreeRoutePreference() {
+        lock(_treeRouteGate) {
+            if(DateTimeOffset.UtcNow > _treeRoutePreferenceUntilUtc) {
+                _treeRoutePreference = TreeRoutePreference.None;
+                _treeRoutePreferenceUntilUtc = DateTimeOffset.MinValue;
+            }
+
+            return _treeRoutePreference;
+        }
+    }
 
     /// <summary>API用のファイル変更ペイロードに変換する。</summary>
     /// <param name="file">PRに含めるファイル情報。</param>
@@ -470,4 +768,39 @@ public class ApiService( HttpClient? httpClient = null ) : IApiService {
     /// <param name="RequestAdapter">KiotaのHTTP変換アダプター。</param>
     /// <param name="ApiClient">Kiota生成のAPIクライアント。</param>
     private sealed record ApiClientContext( HttpClient HttpClient, HttpClientRequestAdapter RequestAdapter, DcsApiClient ApiClient );
+
+    /// <summary>
+    /// Tree API 試行結果を保持する。
+    /// </summary>
+    /// <param name="PathLabel">試行経路ラベル。</param>
+    /// <param name="Result">実行結果。</param>
+    /// <param name="HttpElapsedMs">HTTP 区間の経過時間。</param>
+    /// <param name="DeserializeElapsedMs">逆シリアライズ区間の経過時間。</param>
+    /// <param name="MapElapsedMs">マッピング区間の経過時間。</param>
+    /// <param name="TotalElapsedMs">全体経過時間。</param>
+    /// <param name="RawCount">受信件数。</param>
+    /// <param name="MappedCount">変換件数。</param>
+    /// <param name="StatusCode">HTTP ステータスコード。</param>
+    /// <param name="TimedOut">タイムアウトで失敗したかどうか。</param>
+    private sealed record TreeRequestAttempt(
+        string PathLabel,
+        Result<IReadOnlyList<FileEntry>> Result,
+        long HttpElapsedMs,
+        long DeserializeElapsedMs,
+        long MapElapsedMs,
+        long TotalElapsedMs,
+        int RawCount,
+        int MappedCount,
+        int? StatusCode,
+        bool TimedOut
+    );
+
+    /// <summary>
+    /// Tree API 呼び出しで記憶する経路優先を表す。
+    /// </summary>
+    private enum TreeRoutePreference {
+        None,
+        Default,
+        Ipv4,
+    }
 }

--- a/src/DcsTranslationTool.Infrastructure/Services/FileEntryHashCacheService.cs
+++ b/src/DcsTranslationTool.Infrastructure/Services/FileEntryHashCacheService.cs
@@ -1,0 +1,391 @@
+using System.Reflection;
+
+using DcsTranslationTool.Application.Interfaces;
+using DcsTranslationTool.Infrastructure.Interfaces;
+
+using Microsoft.Data.Sqlite;
+
+namespace DcsTranslationTool.Infrastructure.Services;
+
+/// <summary>
+/// SQLite を利用してファイル SHA1 キャッシュを永続化する。
+/// </summary>
+public sealed class FileEntryHashCacheService(
+    ILoggingService logger,
+    string? preferredBaseDirectory = null,
+    string? fallbackBaseDirectory = null
+) : IFileEntryHashCacheService, IDisposable {
+    private const string PreferredCacheDirectoryName = ".dcs-translation-cache";
+    private const string FallbackCacheDirectoryName = "cache";
+    private const string CacheFileName = "hashcache.db";
+
+    private readonly object _gate = new();
+    private readonly Dictionary<string, CacheEntry> _index = new( StringComparer.OrdinalIgnoreCase );
+    private readonly string _preferredBaseDirectory = ResolvePreferredBaseDirectory( preferredBaseDirectory );
+    private readonly string _fallbackBaseDirectory = ResolveFallbackBaseDirectory( fallbackBaseDirectory );
+
+    private SqliteConnection? _connection;
+    private string _currentRootPath = string.Empty;
+
+    /// <inheritdoc />
+    public void ConfigureRoot( string rootPath ) {
+        ArgumentException.ThrowIfNullOrWhiteSpace( rootPath );
+        var normalizedRoot = Path.GetFullPath( rootPath );
+
+        lock(_gate) {
+            if(string.Equals( _currentRootPath, normalizedRoot, StringComparison.OrdinalIgnoreCase ) && _connection is not null) {
+                return;
+            }
+
+            DisposeConnection();
+            _index.Clear();
+
+            var preferredDbPath = Path.Combine( _preferredBaseDirectory, PreferredCacheDirectoryName, CacheFileName );
+            if(!TryOpenConnection( preferredDbPath, out var connection, out var exception )) {
+                logger.Warn( $"キャッシュDBの同階層初期化に失敗したためフォールバックする。Path={preferredDbPath}", exception );
+                var fallbackDbPath = Path.Combine( _fallbackBaseDirectory, FallbackCacheDirectoryName, CacheFileName );
+                if(!TryOpenConnection( fallbackDbPath, out connection, out var fallbackException )) {
+                    throw new InvalidOperationException( $"キャッシュDBの初期化に失敗した。FallbackPath={fallbackDbPath}", fallbackException );
+                }
+
+                logger.Info( $"ハッシュキャッシュ保存先にフォールバックを適用した。Path={fallbackDbPath}" );
+            }
+            else {
+                logger.Info( $"ハッシュキャッシュ保存先を実行ファイル同階層に設定した。Path={preferredDbPath}" );
+            }
+
+            _connection = connection!;
+            InitializeSchema( _connection );
+            LoadIndex( _connection, normalizedRoot );
+
+            _currentRootPath = normalizedRoot;
+            logger.Info( $"ハッシュキャッシュを初期化した。Root={_currentRootPath}, Count={_index.Count}" );
+        }
+    }
+
+    /// <inheritdoc />
+    public bool TryGetSha( string relativePath, long fileSize, DateTime lastWriteUtc, out string? sha ) {
+        ArgumentException.ThrowIfNullOrWhiteSpace( relativePath );
+        var normalizedPath = NormalizeRelativePath( relativePath );
+        var ticks = lastWriteUtc.ToUniversalTime().Ticks;
+
+        lock(_gate) {
+            if(_index.TryGetValue( normalizedPath, out var entry )
+                && entry.FileSize == fileSize
+                && entry.LastWriteUtcTicks == ticks
+                && !string.IsNullOrWhiteSpace( entry.Sha )) {
+                sha = entry.Sha;
+                return true;
+            }
+        }
+
+        sha = null;
+        return false;
+    }
+
+    /// <inheritdoc />
+    public void Upsert( string relativePath, long fileSize, DateTime lastWriteUtc, string? sha ) {
+        ArgumentException.ThrowIfNullOrWhiteSpace( relativePath );
+        var normalizedPath = NormalizeRelativePath( relativePath );
+        var ticks = lastWriteUtc.ToUniversalTime().Ticks;
+        var updatedAtTicks = DateTime.UtcNow.Ticks;
+
+        lock(_gate) {
+            EnsureConnection();
+
+            using var command = _connection!.CreateCommand();
+            command.CommandText = """
+                                  INSERT INTO file_hash_cache(root_path, path, file_size, last_write_utc_ticks, sha1, updated_at_utc_ticks)
+                                  VALUES($rootPath, $path, $fileSize, $lastWriteUtcTicks, $sha1, $updatedAtUtcTicks)
+                                  ON CONFLICT(root_path, path) DO UPDATE SET
+                                      file_size = excluded.file_size,
+                                      last_write_utc_ticks = excluded.last_write_utc_ticks,
+                                      sha1 = excluded.sha1,
+                                      updated_at_utc_ticks = excluded.updated_at_utc_ticks;
+                                  """;
+            command.Parameters.AddWithValue( "$rootPath", _currentRootPath );
+            command.Parameters.AddWithValue( "$path", normalizedPath );
+            command.Parameters.AddWithValue( "$fileSize", fileSize );
+            command.Parameters.AddWithValue( "$lastWriteUtcTicks", ticks );
+            command.Parameters.AddWithValue( "$sha1", (object?)sha ?? DBNull.Value );
+            command.Parameters.AddWithValue( "$updatedAtUtcTicks", updatedAtTicks );
+            command.ExecuteNonQuery();
+
+            _index[normalizedPath] = new CacheEntry( fileSize, ticks, sha );
+        }
+    }
+
+    /// <inheritdoc />
+    public void Remove( string relativePath ) {
+        ArgumentException.ThrowIfNullOrWhiteSpace( relativePath );
+        var normalizedPath = NormalizeRelativePath( relativePath );
+
+        lock(_gate) {
+            if(_connection is null) {
+                _index.Remove( normalizedPath );
+                return;
+            }
+
+            using var command = _connection.CreateCommand();
+            command.CommandText = "DELETE FROM file_hash_cache WHERE root_path = $rootPath AND path = $path;";
+            command.Parameters.AddWithValue( "$rootPath", _currentRootPath );
+            command.Parameters.AddWithValue( "$path", normalizedPath );
+            command.ExecuteNonQuery();
+            _index.Remove( normalizedPath );
+        }
+    }
+
+    /// <inheritdoc />
+    public void Prune( IReadOnlySet<string> existingRelativePaths ) {
+        ArgumentNullException.ThrowIfNull( existingRelativePaths );
+
+        lock(_gate) {
+            if(_connection is null || _index.Count == 0) {
+                return;
+            }
+
+            var normalizedExistingPaths = new HashSet<string>(
+                existingRelativePaths.Select( NormalizeRelativePath ),
+                StringComparer.OrdinalIgnoreCase
+            );
+            var stalePaths = _index.Keys
+                .Where( path => !normalizedExistingPaths.Contains( path ) )
+                .ToArray();
+            if(stalePaths.Length == 0) {
+                return;
+            }
+
+            using var transaction = _connection.BeginTransaction();
+            foreach(var stalePath in stalePaths) {
+                using var command = _connection.CreateCommand();
+                command.Transaction = transaction;
+                command.CommandText = "DELETE FROM file_hash_cache WHERE root_path = $rootPath AND path = $path;";
+                command.Parameters.AddWithValue( "$rootPath", _currentRootPath );
+                command.Parameters.AddWithValue( "$path", stalePath );
+                command.ExecuteNonQuery();
+                _index.Remove( stalePath );
+            }
+            transaction.Commit();
+            logger.Info( $"未使用のハッシュキャッシュを削除した。Count={stalePaths.Length}" );
+        }
+    }
+
+    /// <inheritdoc />
+    public void Dispose() {
+        lock(_gate) {
+            DisposeConnection();
+            _index.Clear();
+            _currentRootPath = string.Empty;
+        }
+    }
+
+    /// <summary>
+    /// 接続が初期化済みであることを保証する。
+    /// </summary>
+    private void EnsureConnection() {
+        if(_connection is null) {
+            throw new InvalidOperationException( "キャッシュ接続が初期化されていない。" );
+        }
+    }
+
+    /// <summary>
+    /// 相対パスを正規化する。
+    /// </summary>
+    /// <param name="relativePath">正規化対象パス。</param>
+    /// <returns>正規化した相対パス。</returns>
+    private static string NormalizeRelativePath( string relativePath ) =>
+        relativePath.Replace( "\\", "/", StringComparison.Ordinal ).TrimStart( '/' );
+
+    /// <summary>
+    /// DB 接続を安全に破棄する。
+    /// </summary>
+    private void DisposeConnection() {
+        if(_connection is null) {
+            return;
+        }
+
+        try {
+            _connection.Dispose();
+        }
+        catch(Exception ex) {
+            logger.Warn( "ハッシュキャッシュ接続の破棄時に例外が発生した。", ex );
+        }
+        finally {
+            _connection = null;
+        }
+    }
+
+    /// <summary>
+    /// 接続確立を試行する。
+    /// </summary>
+    /// <param name="dbPath">DB ファイルパス。</param>
+    /// <param name="connection">確立済み接続。</param>
+    /// <param name="exception">失敗時の例外。</param>
+    /// <returns>接続できた場合は <see langword="true"/> を返す。</returns>
+    private static bool TryOpenConnection( string dbPath, out SqliteConnection? connection, out Exception? exception ) {
+        connection = null;
+        exception = null;
+        try {
+            var directory = Path.GetDirectoryName( dbPath ) ?? throw new InvalidOperationException( "DBディレクトリを解決できない。" );
+            Directory.CreateDirectory( directory );
+            connection = new SqliteConnection( $"Data Source={dbPath};Pooling=False" );
+            connection.Open();
+            return true;
+        }
+        catch(Exception ex) {
+            connection?.Dispose();
+            connection = null;
+            exception = ex;
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// テーブルとインデックスを初期化する。
+    /// </summary>
+    /// <param name="connection">初期化対象接続。</param>
+    private static void InitializeSchema( SqliteConnection connection ) {
+        using(var pragma = connection.CreateCommand()) {
+            pragma.CommandText = """
+                                PRAGMA journal_mode = WAL;
+                                PRAGMA synchronous = NORMAL;
+                                """;
+            pragma.ExecuteNonQuery();
+        }
+
+        EnsureSchemaV2( connection );
+
+        using var create = connection.CreateCommand();
+        create.CommandText = """
+                             CREATE TABLE IF NOT EXISTS file_hash_cache (
+                                 root_path TEXT NOT NULL,
+                                 path TEXT NOT NULL,
+                                 file_size INTEGER NOT NULL,
+                                 last_write_utc_ticks INTEGER NOT NULL,
+                                 sha1 TEXT NULL,
+                                 updated_at_utc_ticks INTEGER NOT NULL,
+                                 PRIMARY KEY(root_path, path)
+                             );
+                             CREATE INDEX IF NOT EXISTS ix_file_hash_cache_updated_at
+                             ON file_hash_cache(root_path, updated_at_utc_ticks);
+                             """;
+        create.ExecuteNonQuery();
+    }
+
+    /// <summary>
+    /// DB からインデックスを読み込む。
+    /// </summary>
+    /// <param name="connection">読込対象接続。</param>
+    /// <param name="rootPath">読み込むルートパス。</param>
+    private void LoadIndex( SqliteConnection connection, string rootPath ) {
+        using var select = connection.CreateCommand();
+        select.CommandText = """
+                             SELECT path, file_size, last_write_utc_ticks, sha1
+                             FROM file_hash_cache
+                             WHERE root_path = $rootPath;
+                             """;
+        select.Parameters.AddWithValue( "$rootPath", rootPath );
+        using var reader = select.ExecuteReader();
+        while(reader.Read()) {
+            var relativePath = reader.GetString( 0 );
+            var fileSize = reader.GetInt64( 1 );
+            var lastWriteTicks = reader.GetInt64( 2 );
+            var sha = reader.IsDBNull( 3 ) ? null : reader.GetString( 3 );
+            _index[relativePath] = new CacheEntry( fileSize, lastWriteTicks, sha );
+        }
+    }
+
+    /// <summary>
+    /// 旧スキーマを検出した場合に v2 スキーマへ移行する。
+    /// </summary>
+    /// <param name="connection">対象接続。</param>
+    private static void EnsureSchemaV2( SqliteConnection connection ) {
+        using var check = connection.CreateCommand();
+        check.CommandText = """
+                             SELECT COUNT(*)
+                             FROM sqlite_master
+                             WHERE type='table' AND name='file_hash_cache';
+                             """;
+        var exists = Convert.ToInt64( check.ExecuteScalar() ) > 0;
+        if(!exists) {
+            return;
+        }
+
+        using var tableInfo = connection.CreateCommand();
+        tableInfo.CommandText = "PRAGMA table_info(file_hash_cache);";
+        using var reader = tableInfo.ExecuteReader();
+        var hasRootPath = false;
+        while(reader.Read()) {
+            if(string.Equals( reader.GetString( 1 ), "root_path", StringComparison.OrdinalIgnoreCase )) {
+                hasRootPath = true;
+                break;
+            }
+        }
+
+        if(hasRootPath) {
+            return;
+        }
+
+        using var migrate = connection.CreateCommand();
+        migrate.CommandText = """
+                              ALTER TABLE file_hash_cache RENAME TO file_hash_cache_v1;
+                              CREATE TABLE file_hash_cache (
+                                  root_path TEXT NOT NULL,
+                                  path TEXT NOT NULL,
+                                  file_size INTEGER NOT NULL,
+                                  last_write_utc_ticks INTEGER NOT NULL,
+                                  sha1 TEXT NULL,
+                                  updated_at_utc_ticks INTEGER NOT NULL,
+                                  PRIMARY KEY(root_path, path)
+                              );
+                              INSERT INTO file_hash_cache(root_path, path, file_size, last_write_utc_ticks, sha1, updated_at_utc_ticks)
+                              SELECT '' AS root_path, path, file_size, last_write_utc_ticks, sha1, updated_at_utc_ticks
+                              FROM file_hash_cache_v1;
+                              DROP TABLE file_hash_cache_v1;
+                              """;
+        migrate.ExecuteNonQuery();
+    }
+
+    /// <summary>
+    /// 優先保存先ベースディレクトリを解決する。
+    /// </summary>
+    /// <param name="preferredBaseDirectory">明示指定の優先パス。</param>
+    /// <returns>優先保存先ベースディレクトリ。</returns>
+    private static string ResolvePreferredBaseDirectory( string? preferredBaseDirectory ) {
+        if(!string.IsNullOrWhiteSpace( preferredBaseDirectory )) {
+            return Path.GetFullPath( preferredBaseDirectory );
+        }
+
+        var processPath = Environment.ProcessPath;
+        var baseDirectory = !string.IsNullOrWhiteSpace( processPath )
+            ? Path.GetDirectoryName( processPath )
+            : null;
+        baseDirectory ??= AppContext.BaseDirectory;
+        return Path.GetFullPath( baseDirectory );
+    }
+
+    /// <summary>
+    /// フォールバック保存先ベースディレクトリを解決する。
+    /// </summary>
+    /// <param name="fallbackBaseDirectory">明示指定のフォールバックパス。</param>
+    /// <returns>フォールバック保存先ベースディレクトリ。</returns>
+    private static string ResolveFallbackBaseDirectory( string? fallbackBaseDirectory ) {
+        if(!string.IsNullOrWhiteSpace( fallbackBaseDirectory )) {
+            return Path.GetFullPath( fallbackBaseDirectory );
+        }
+
+        var assembly = Assembly.GetEntryAssembly() ?? Assembly.GetExecutingAssembly();
+        var title = assembly.GetCustomAttribute<AssemblyTitleAttribute>()?.Title;
+        title = string.IsNullOrWhiteSpace( title ) ? "DcsTranslationTool" : title;
+        var appData = Environment.GetFolderPath( Environment.SpecialFolder.ApplicationData );
+        return Path.Combine( appData, title );
+    }
+
+    /// <summary>
+    /// キャッシュ要素を表す。
+    /// </summary>
+    /// <param name="FileSize">ファイルサイズ。</param>
+    /// <param name="LastWriteUtcTicks">更新日時（Ticks）。</param>
+    /// <param name="Sha">SHA1。</param>
+    private sealed record CacheEntry( long FileSize, long LastWriteUtcTicks, string? Sha );
+}

--- a/src/DcsTranslationTool.Infrastructure/Services/TreeHttpClientProvider.cs
+++ b/src/DcsTranslationTool.Infrastructure/Services/TreeHttpClientProvider.cs
@@ -1,0 +1,127 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Sockets;
+
+using DcsTranslationTool.Infrastructure.Interfaces;
+
+namespace DcsTranslationTool.Infrastructure.Services;
+
+/// <summary>
+/// Tree API 用の default / IPv4 優先クライアントを供給する。
+/// </summary>
+public sealed class TreeHttpClientProvider(
+    HttpClient? defaultClient = null,
+    HttpClient? ipv4PreferredClient = null
+) : ITreeHttpClientProvider {
+    private const string DefaultBaseUrl = "https://dcs-translation-japanese-cloudflare-worker.dcs-translation-japanese.workers.dev/";
+
+    private readonly TreeClientBundle _bundle = CreateBundle( defaultClient, ipv4PreferredClient );
+
+    /// <inheritdoc />
+    public HttpClient DefaultClient => this._bundle.DefaultClient;
+
+    /// <inheritdoc />
+    public HttpClient Ipv4PreferredClient => this._bundle.Ipv4PreferredClient;
+
+    /// <inheritdoc />
+    public bool IsIpv4PreferredDedicated => this._bundle.IsIpv4PreferredDedicated;
+
+    /// <summary>
+    /// 呼び出し条件に応じて default / IPv4 優先クライアントを組み立てる。
+    /// </summary>
+    /// <param name="defaultClient">既定経路の外部クライアント。</param>
+    /// <param name="ipv4PreferredClient">IPv4 優先経路の外部クライアント。</param>
+    /// <returns>初期化済みクライアント束。</returns>
+    private static TreeClientBundle CreateBundle( HttpClient? defaultClient, HttpClient? ipv4PreferredClient ) {
+        var normalizedDefaultClient = InitializeClient( defaultClient );
+
+        if(ipv4PreferredClient is not null) {
+            var normalizedIpv4Client = InitializeClient( ipv4PreferredClient, normalizedDefaultClient );
+            return new TreeClientBundle( normalizedDefaultClient, normalizedIpv4Client, true );
+        }
+
+        if(defaultClient is not null)
+            return new TreeClientBundle( normalizedDefaultClient, normalizedDefaultClient, false );
+
+        var generatedIpv4Client = InitializeIpv4PreferredClient( normalizedDefaultClient );
+        return new TreeClientBundle( normalizedDefaultClient, generatedIpv4Client, true );
+    }
+
+    /// <summary>
+    /// 渡された <see cref="HttpClient"/> を初期化する。未指定時は新規生成する。
+    /// </summary>
+    /// <param name="client">初期化対象クライアント。</param>
+    /// <param name="fallbackClient">既定値継承元クライアント。</param>
+    /// <returns>初期化済み <see cref="HttpClient"/>。</returns>
+    private static HttpClient InitializeClient( HttpClient? client, HttpClient? fallbackClient = null ) {
+        var resolvedClient = client ?? new HttpClient();
+
+        resolvedClient.BaseAddress ??= fallbackClient?.BaseAddress ?? new Uri( DefaultBaseUrl );
+        if(resolvedClient.DefaultRequestHeaders.Accept.All( header => header.MediaType != "application/json" ))
+            resolvedClient.DefaultRequestHeaders.Accept.Add( new MediaTypeWithQualityHeaderValue( "application/json" ) );
+
+        return resolvedClient;
+    }
+
+    /// <summary>
+    /// IPv4 優先の接続設定を持つ <see cref="HttpClient"/> を初期化する。
+    /// </summary>
+    /// <param name="sourceClient">既定値継承元クライアント。</param>
+    /// <returns>初期化済み <see cref="HttpClient"/>。</returns>
+    private static HttpClient InitializeIpv4PreferredClient( HttpClient sourceClient ) {
+        var handler = new SocketsHttpHandler
+        {
+            AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate | DecompressionMethods.Brotli,
+            PooledConnectionLifetime = TimeSpan.FromMinutes( 5 ),
+            ConnectTimeout = TimeSpan.FromSeconds( 10 ),
+            ConnectCallback = async ( context, token ) => {
+                var addresses = await Dns.GetHostAddressesAsync( context.DnsEndPoint.Host, token ).ConfigureAwait( false );
+                var preferredAddresses = addresses
+                    .Where( address => address.AddressFamily == AddressFamily.InterNetwork )
+                    .ToArray();
+                var candidates = preferredAddresses.Length > 0 ? preferredAddresses : addresses;
+
+                Exception? lastException = null;
+                foreach(var address in candidates) {
+                    var socket = new Socket( address.AddressFamily, SocketType.Stream, ProtocolType.Tcp );
+                    try {
+                        await socket.ConnectAsync( new IPEndPoint( address, context.DnsEndPoint.Port ), token ).ConfigureAwait( false );
+                        return new NetworkStream( socket, ownsSocket: true );
+                    }
+                    catch(Exception ex) {
+                        lastException = ex;
+                        socket.Dispose();
+                    }
+                }
+
+                throw new HttpRequestException( $"接続可能なアドレスが見つからない。Host={context.DnsEndPoint.Host}", lastException );
+            },
+        };
+
+        var client = new HttpClient( handler )
+        {
+            BaseAddress = sourceClient.BaseAddress ?? new Uri( DefaultBaseUrl ),
+            Timeout = sourceClient.Timeout,
+            DefaultRequestVersion = sourceClient.DefaultRequestVersion,
+            DefaultVersionPolicy = sourceClient.DefaultVersionPolicy,
+            MaxResponseContentBufferSize = sourceClient.MaxResponseContentBufferSize,
+        };
+
+        foreach(var header in sourceClient.DefaultRequestHeaders) {
+            client.DefaultRequestHeaders.TryAddWithoutValidation( header.Key, header.Value );
+        }
+
+        if(client.DefaultRequestHeaders.Accept.All( header => header.MediaType != "application/json" ))
+            client.DefaultRequestHeaders.Accept.Add( new MediaTypeWithQualityHeaderValue( "application/json" ) );
+
+        return client;
+    }
+
+    /// <summary>
+    /// Tree API に利用するクライアント束を表す。
+    /// </summary>
+    /// <param name="DefaultClient">既定経路クライアント。</param>
+    /// <param name="Ipv4PreferredClient">IPv4 優先経路クライアント。</param>
+    /// <param name="IsIpv4PreferredDedicated">IPv4 優先経路が専用クライアントかどうか。</param>
+    private sealed record TreeClientBundle( HttpClient DefaultClient, HttpClient Ipv4PreferredClient, bool IsIpv4PreferredDedicated );
+}

--- a/src/DcsTranslationTool.Infrastructure/packages.lock.json
+++ b/src/DcsTranslationTool.Infrastructure/packages.lock.json
@@ -12,6 +12,17 @@
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
       },
+      "Microsoft.Data.Sqlite": {
+        "type": "Direct",
+        "requested": "[9.0.10, )",
+        "resolved": "9.0.10",
+        "contentHash": "1waeeEEM/Dp5l2laUByEEWfd6qyI00HExDduhLKGT2kPnHArjIDcMf2z9HIjeLPoR56iBHhvXTfAv1hiH/wAAQ==",
+        "dependencies": {
+          "Microsoft.Data.Sqlite.Core": "9.0.10",
+          "SQLitePCLRaw.bundle_e_sqlite3": "2.1.10",
+          "SQLitePCLRaw.core": "2.1.10"
+        }
+      },
       "Microsoft.Kiota.Abstractions": {
         "type": "Direct",
         "requested": "[1.21.2, )",
@@ -82,6 +93,14 @@
           "System.Text.Encoding.CodePages": "8.0.0"
         }
       },
+      "Microsoft.Data.Sqlite.Core": {
+        "type": "Transitive",
+        "resolved": "9.0.10",
+        "contentHash": "tWbN2uzG4uBxxMjcHA3Oa9ecAYjyRTfDwRbgQ7ueyx7eEgyYbBiKADY2rllF8wO3dHUvN+/8fgylwSGMfiCtVg==",
+        "dependencies": {
+          "SQLitePCLRaw.core": "2.1.10"
+        }
+      },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "Transitive",
         "resolved": "2.1.1",
@@ -92,10 +111,45 @@
         "resolved": "3.0.1",
         "contentHash": "s/s20YTVY9r9TPfTrN5g8zPF1YhwxyqO6PxUkrYTGI2B+OGPe9AdajWZrLhFqXIvqIW23fnUE4+ztrUWNU1+9g=="
       },
+      "SQLitePCLRaw.bundle_e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "2.1.10",
+        "contentHash": "UxWuisvZ3uVcVOLJQv7urM/JiQH+v3TmaJc1BLKl5Dxfm/nTzTUrqswCqg/INiYLi61AXnHo1M1JPmPqqLnAdg==",
+        "dependencies": {
+          "SQLitePCLRaw.lib.e_sqlite3": "2.1.10",
+          "SQLitePCLRaw.provider.e_sqlite3": "2.1.10"
+        }
+      },
+      "SQLitePCLRaw.core": {
+        "type": "Transitive",
+        "resolved": "2.1.10",
+        "contentHash": "Ii8JCbC7oiVclaE/mbDEK000EFIJ+ShRPwAvvV89GOZhQ+ZLtlnSWl6ksCNMKu/VGXA4Nfi2B7LhN/QFN9oBcw==",
+        "dependencies": {
+          "System.Memory": "4.5.3"
+        }
+      },
+      "SQLitePCLRaw.lib.e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "2.1.10",
+        "contentHash": "mAr69tDbnf3QJpRy2nJz8Qdpebdil00fvycyByR58Cn9eARvR+UiG2Vzsp+4q1tV3ikwiYIjlXCQFc12GfebbA=="
+      },
+      "SQLitePCLRaw.provider.e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "2.1.10",
+        "contentHash": "uZVTi02C1SxqzgT0HqTWatIbWGb40iIkfc3FpFCpE/r7g6K0PqzDUeefL6P6HPhDtc6BacN3yQysfzP7ks+wSQ==",
+        "dependencies": {
+          "SQLitePCLRaw.core": "2.1.10"
+        }
+      },
       "Std.UriTemplate": {
         "type": "Transitive",
         "resolved": "2.0.8",
         "contentHash": "IAR4gJlLVD4r/FsU/rDb1+9sbB3/tCFVZz5IzlbM2yHoiUisBi5Ek/KXRUF7RcqNARka79EoaOz9INnXvQ/O6w=="
+      },
+      "System.Memory": {
+        "type": "Transitive",
+        "resolved": "4.5.3",
+        "contentHash": "3oDzvc/zzetpTKWMShs1AADwZjQ/36HnsufHRPcOjyRAAMLDlu2iD33MBI2opxnezcVUtXyqDXXjoFMOU9c7SA=="
       },
       "System.Text.Encoding.CodePages": {
         "type": "Transitive",

--- a/src/DcsTranslationTool.Presentation.Wpf/Features/CreatePullRequest/CreatePullRequestViewModel.cs
+++ b/src/DcsTranslationTool.Presentation.Wpf/Features/CreatePullRequest/CreatePullRequestViewModel.cs
@@ -10,7 +10,6 @@ using DcsTranslationTool.Application.Contracts;
 using DcsTranslationTool.Application.Enums;
 using DcsTranslationTool.Application.Interfaces;
 using DcsTranslationTool.Application.Models;
-using DcsTranslationTool.Presentation.Wpf.Services;
 using DcsTranslationTool.Presentation.Wpf.UI.Dialogs.Items;
 using DcsTranslationTool.Presentation.Wpf.UI.Dialogs.Parameters;
 using DcsTranslationTool.Presentation.Wpf.UI.Dialogs.Results;

--- a/src/DcsTranslationTool.Presentation.Wpf/Features/Download/DownloadView.xaml
+++ b/src/DcsTranslationTool.Presentation.Wpf/Features/Download/DownloadView.xaml
@@ -11,7 +11,7 @@
       xmlns:enums="clr-namespace:DcsTranslationTool.Presentation.Wpf.UI.Enums"
       xmlns:md="http://materialdesigninxaml.net/winfx/xaml/themes"
       xmlns:cal="http://www.caliburnproject.org"
-      d:DataContext="{d:DesignInstance Type=local:DownloadViewModel}"
+      d:DataContext="{d:DesignInstance Type=local:DownloadView}"
       mc:Ignorable="d"
       d:DesignHeight="450" d:DesignWidth="800">
 
@@ -96,7 +96,12 @@
 
                 <TabControl.ContentTemplate>
                     <DataTemplate DataType="{x:Type vm:TabItemViewModel}">
-                        <TreeView x:Name="TreeViewControl" ItemsSource="{Binding Root.Children}" Margin="{StaticResource XSmallTopMargin}">
+                        <TreeView x:Name="TreeViewControl"
+                                  ItemsSource="{Binding Root.Children}"
+                                  Margin="{StaticResource XSmallTopMargin}"
+                                  VirtualizingStackPanel.IsVirtualizing="True"
+                                  VirtualizingStackPanel.VirtualizationMode="Recycling"
+                                  ScrollViewer.CanContentScroll="True">
                             <TreeView.ItemContainerStyle>
                                 <Style TargetType="TreeViewItem">
                                     <Setter Property="IsExpanded" Value="{Binding IsExpanded, Mode=TwoWay}"/>

--- a/src/DcsTranslationTool.Presentation.Wpf/Features/Download/DownloadViewModel.cs
+++ b/src/DcsTranslationTool.Presentation.Wpf/Features/Download/DownloadViewModel.cs
@@ -1,9 +1,7 @@
 using DcsTranslationTool.Application.Interfaces;
 using DcsTranslationTool.Presentation.Wpf.Features.Common;
-using DcsTranslationTool.Presentation.Wpf.Services;
 using DcsTranslationTool.Presentation.Wpf.Services.Abstractions;
 using DcsTranslationTool.Presentation.Wpf.UI.Enums;
-using DcsTranslationTool.Presentation.Wpf.UI.Interfaces;
 using DcsTranslationTool.Presentation.Wpf.ViewModels;
 
 namespace DcsTranslationTool.Presentation.Wpf.Features.Download;

--- a/src/DcsTranslationTool.Presentation.Wpf/Features/Main/MainViewModel.cs
+++ b/src/DcsTranslationTool.Presentation.Wpf/Features/Main/MainViewModel.cs
@@ -2,7 +2,6 @@ using Caliburn.Micro;
 
 using DcsTranslationTool.Presentation.Wpf.Features.Download;
 using DcsTranslationTool.Presentation.Wpf.Features.Upload;
-using DcsTranslationTool.Presentation.Wpf.Services;
 
 namespace DcsTranslationTool.Presentation.Wpf.Features.Main;
 

--- a/src/DcsTranslationTool.Presentation.Wpf/Features/Settings/SettingsViewModel.cs
+++ b/src/DcsTranslationTool.Presentation.Wpf/Features/Settings/SettingsViewModel.cs
@@ -1,7 +1,6 @@
 using Caliburn.Micro;
 
 using DcsTranslationTool.Application.Interfaces;
-using DcsTranslationTool.Presentation.Wpf.Services;
 using DcsTranslationTool.Presentation.Wpf.Services.Abstractions;
 
 namespace DcsTranslationTool.Presentation.Wpf.Features.Settings;

--- a/src/DcsTranslationTool.Presentation.Wpf/Features/Upload/UploadView.xaml
+++ b/src/DcsTranslationTool.Presentation.Wpf/Features/Upload/UploadView.xaml
@@ -97,7 +97,12 @@
 
                 <TabControl.ContentTemplate>
                     <DataTemplate DataType="{x:Type vm:TabItemViewModel}">
-                        <TreeView x:Name="TreeViewControl" ItemsSource="{Binding Root.Children}" Margin="{StaticResource XSmallTopMargin}">
+                        <TreeView x:Name="TreeViewControl"
+                                  ItemsSource="{Binding Root.Children}"
+                                  Margin="{StaticResource XSmallTopMargin}"
+                                  VirtualizingStackPanel.IsVirtualizing="True"
+                                  VirtualizingStackPanel.VirtualizationMode="Recycling"
+                                  ScrollViewer.CanContentScroll="True">
                             <TreeView.ItemContainerStyle>
                                 <Style TargetType="TreeViewItem">
                                     <Setter Property="IsExpanded" Value="{Binding IsExpanded, Mode=TwoWay}"/>

--- a/src/DcsTranslationTool.Presentation.Wpf/Features/Upload/UploadViewModel.cs
+++ b/src/DcsTranslationTool.Presentation.Wpf/Features/Upload/UploadViewModel.cs
@@ -5,7 +5,6 @@ using DcsTranslationTool.Application.Interfaces;
 using DcsTranslationTool.Application.Models;
 using DcsTranslationTool.Domain.Models;
 using DcsTranslationTool.Presentation.Wpf.Features.Common;
-using DcsTranslationTool.Presentation.Wpf.Services;
 using DcsTranslationTool.Presentation.Wpf.Services.Abstractions;
 using DcsTranslationTool.Presentation.Wpf.UI.Dialogs.Parameters;
 using DcsTranslationTool.Presentation.Wpf.UI.Enums;
@@ -148,6 +147,11 @@ public sealed class UploadViewModel(
 
     private IEnumerable<CommitFile> GetCommitFiles {
         get {
+            if(SelectedTabIndex < 0 || SelectedTabIndex >= Tabs.Count) {
+                Logger.Warn( $"コミット対象ファイル収集を中断する。SelectedTabIndex={SelectedTabIndex}, TabCount={Tabs.Count}" );
+                return [];
+            }
+
             var files = Tabs[SelectedTabIndex]
             .GetCheckedEntries()
             .Where( e => !e.IsDirectory && e.RepoSha != e.LocalSha )

--- a/src/DcsTranslationTool.Presentation.Wpf/Services/Abstractions/IDialogService.cs
+++ b/src/DcsTranslationTool.Presentation.Wpf/Services/Abstractions/IDialogService.cs
@@ -1,5 +1,3 @@
-using System.Threading;
-
 using DcsTranslationTool.Presentation.Wpf.UI.Dialogs.Parameters;
 using DcsTranslationTool.Presentation.Wpf.UI.Dialogs.Results;
 

--- a/src/DcsTranslationTool.Presentation.Wpf/Services/FileEntryTreeService.cs
+++ b/src/DcsTranslationTool.Presentation.Wpf/Services/FileEntryTreeService.cs
@@ -20,15 +20,12 @@ public sealed class FileEntryTreeService( ILoggingService logger ) : IFileEntryT
         ChangeTypeMode mode
     ) {
         var entries = FileEntryComparisonHelper.Merge( localEntries, repoEntries );
-
-        IFileEntryViewModel rootVm = new FileEntryViewModel(
-            new FileEntry( string.Empty, string.Empty, true ),
-            mode,
-            logger
-        );
+        var rootNode = new TreeNode( string.Empty, string.Empty, true );
         foreach(var entry in entries) {
-            this.AddFileEntryToTree( rootVm, entry, mode );
+            AddFileEntryToTree( rootNode, entry );
         }
+
+        var rootVm = this.BuildViewModelTree( rootNode, mode );
 
         var tabs = Enum.GetValues<CategoryType>()
             .Select( tabType => this.BuildTabItem( tabType, rootVm, mode ) )
@@ -38,8 +35,8 @@ public sealed class FileEntryTreeService( ILoggingService logger ) : IFileEntryT
 
     /// <inheritdoc/>
     public void ApplyFilter( IEnumerable<TabItemViewModel> tabs, HashSet<FileChangeType?> types ) {
-        foreach(var tab in tabs) {
-            this.ApplyFilterRecursive( tab.Root, types );
+        foreach(var tab in tabs.ToArray()) {
+            ApplyFilterRecursive( tab.Root, types );
         }
     }
 
@@ -53,7 +50,7 @@ public sealed class FileEntryTreeService( ILoggingService logger ) : IFileEntryT
     private TabItemViewModel BuildTabItem( CategoryType tabType, IFileEntryViewModel rootVm, ChangeTypeMode mode ) {
         IFileEntryViewModel? target = rootVm;
         foreach(var name in tabType.GetRepoDirRoot()) {
-            target = target?.Children.FirstOrDefault( child => child?.Name == name );
+            target = target?.Children.FirstOrDefault( child => child is { Name: var childName, IsDirectory: true } && childName == name );
             if(target is null) {
                 break;
             }
@@ -76,12 +73,12 @@ public sealed class FileEntryTreeService( ILoggingService logger ) : IFileEntryT
     /// <param name="node">適用対象ノード。</param>
     /// <param name="types">可視とする変更種別集合。</param>
     /// <returns>可視である場合は <see langword="true"/>。</returns>
-    private bool ApplyFilterRecursive( IFileEntryViewModel node, HashSet<FileChangeType?> types ) {
+    private static bool ApplyFilterRecursive( IFileEntryViewModel node, HashSet<FileChangeType?> types ) {
         var visible = types.Contains( node.ChangeType );
         if(node.IsDirectory) {
             var childVisible = false;
-            foreach(var child in node.Children) {
-                if(this.ApplyFilterRecursive( child, types )) {
+            foreach(var child in node.Children.ToArray()) {
+                if(ApplyFilterRecursive( child, types )) {
                     childVisible = true;
                 }
             }
@@ -97,37 +94,106 @@ public sealed class FileEntryTreeService( ILoggingService logger ) : IFileEntryT
     /// </summary>
     /// <param name="root">ルートノード。</param>
     /// <param name="entry">追加対象エントリ。</param>
-    /// <param name="mode">差分判定モード。</param>
-    private void AddFileEntryToTree( IFileEntryViewModel root, FileEntry entry, ChangeTypeMode mode ) {
+    private static void AddFileEntryToTree( TreeNode root, FileEntry entry ) {
         var parts = entry.Path.Split( "/", StringSplitOptions.RemoveEmptyEntries );
         if(parts.Length == 0) {
             return;
         }
 
-        IFileEntryViewModel current = root;
+        var current = root;
         var absolutePath = string.Empty;
 
-        foreach(var part in parts[..^1]) {
+        for(var index = 0; index < parts.Length; index++) {
+            var part = parts[index];
             absolutePath += absolutePath.Length == 0 ? part : "/" + part;
-            var next = current.Children.FirstOrDefault( child => child?.Name == part && child.IsDirectory );
+            var isLeaf = index == parts.Length - 1;
+            var expectedIsDirectory = !isLeaf || entry.IsDirectory;
+            var next = current.Children.FirstOrDefault( child => child.Name == part && child.IsDirectory == expectedIsDirectory );
             if(next is null) {
-                next = new FileEntryViewModel( new FileEntry( part, absolutePath, true ), mode, logger );
+                next = new TreeNode(
+                    part,
+                    absolutePath,
+                    expectedIsDirectory,
+                    isLeaf ? entry.LocalSha : null,
+                    isLeaf ? entry.RepoSha : null
+                );
                 current.Children.Add( next );
             }
+
+            if(isLeaf) {
+                next.LocalSha = entry.LocalSha;
+                next.RepoSha = entry.RepoSha;
+            }
+
             current = next;
         }
+    }
 
-        var last = parts[^1];
-        if(current.Children.Any( child => child?.Name == last )) {
-            return;
+    /// <summary>
+    /// 内部ノードツリーから <see cref="IFileEntryViewModel"/> ツリーを構築する。
+    /// </summary>
+    /// <param name="node">変換対象ノード。</param>
+    /// <param name="mode">差分判定モード。</param>
+    /// <returns>構築済みノード。</returns>
+    private IFileEntryViewModel BuildViewModelTree( TreeNode node, ChangeTypeMode mode ) {
+        var viewModel = new FileEntryViewModel(
+            new FileEntry( node.Name, node.Path, node.IsDirectory, node.LocalSha, node.RepoSha ),
+            mode,
+            logger
+        );
+
+        foreach(var child in node.Children
+            .OrderBy( child => child.Name, StringComparer.Ordinal )
+            .ThenByDescending( child => child.IsDirectory )) {
+            viewModel.Children.Add( this.BuildViewModelTree( child, mode ) );
         }
 
-        current.Children.Add(
-            new FileEntryViewModel(
-                new FileEntry( last, entry.Path, entry.IsDirectory, entry.LocalSha, entry.RepoSha ),
-                mode,
-                logger
-            )
-        );
+        return viewModel;
+    }
+
+    /// <summary>
+    /// ツリー構築用の内部ノードを表す。
+    /// </summary>
+    /// <param name="name">ノード名。</param>
+    /// <param name="path">ルートからのパス。</param>
+    /// <param name="isDirectory">ディレクトリかどうか。</param>
+    /// <param name="localSha">ローカル SHA。</param>
+    /// <param name="repoSha">リポジトリ SHA。</param>
+    private sealed class TreeNode(
+        string name,
+        string path,
+        bool isDirectory,
+        string? localSha = null,
+        string? repoSha = null
+    ) {
+        /// <summary>
+        /// ノード名を取得する。
+        /// </summary>
+        public string Name { get; } = name;
+
+        /// <summary>
+        /// ルートからのパスを取得する。
+        /// </summary>
+        public string Path { get; } = path;
+
+        /// <summary>
+        /// ディレクトリかどうかを取得する。
+        /// </summary>
+        public bool IsDirectory { get; } = isDirectory;
+
+        /// <summary>
+        /// ローカル SHA を取得または設定する。
+        /// </summary>
+        public string? LocalSha { get; set; } = localSha;
+
+        /// <summary>
+        /// リポジトリ SHA を取得または設定する。
+        /// </summary>
+        public string? RepoSha { get; set; } = repoSha;
+
+        /// <summary>
+        /// 子ノード一覧を取得する。
+        /// </summary>
+        public List<TreeNode> Children { get; } = [];
     }
 }

--- a/src/DcsTranslationTool.Presentation.Wpf/ViewModels/FilterViewModel.cs
+++ b/src/DcsTranslationTool.Presentation.Wpf/ViewModels/FilterViewModel.cs
@@ -1,7 +1,6 @@
 using Caliburn.Micro;
 
 using DcsTranslationTool.Domain.Models;
-using DcsTranslationTool.Presentation.Wpf.Services;
 using DcsTranslationTool.Presentation.Wpf.UI.Interfaces;
 
 namespace DcsTranslationTool.Presentation.Wpf.ViewModels;

--- a/src/DcsTranslationTool.Presentation.Wpf/ViewModels/PullRequestChangeKindViewModel.cs
+++ b/src/DcsTranslationTool.Presentation.Wpf/ViewModels/PullRequestChangeKindViewModel.cs
@@ -1,6 +1,5 @@
 using Caliburn.Micro;
 
-using DcsTranslationTool.Presentation.Wpf.Services;
 using DcsTranslationTool.Presentation.Wpf.UI.Enums;
 
 namespace DcsTranslationTool.Presentation.Wpf.ViewModels;

--- a/src/DcsTranslationTool.Presentation.Wpf/ViewModels/TabItemViewModel.cs
+++ b/src/DcsTranslationTool.Presentation.Wpf/ViewModels/TabItemViewModel.cs
@@ -1,6 +1,5 @@
 using Caliburn.Micro;
 
-using DcsTranslationTool.Presentation.Wpf.Services;
 using DcsTranslationTool.Presentation.Wpf.UI.Enums;
 using DcsTranslationTool.Presentation.Wpf.UI.Extensions;
 using DcsTranslationTool.Presentation.Wpf.UI.Interfaces;

--- a/src/DcsTranslationTool.Presentation.Wpf/packages.lock.json
+++ b/src/DcsTranslationTool.Presentation.Wpf/packages.lock.json
@@ -41,6 +41,24 @@
         "resolved": "5.3.0",
         "contentHash": "2+gcPqbWB3f9vvpCXb7SMhObt9aYSIIIkycYjnctnq4smAfzflwTcMQbG3UjiUYKoTbAy4+RXO0tugLX33YhiA=="
       },
+      "Microsoft.Data.Sqlite": {
+        "type": "Transitive",
+        "resolved": "9.0.10",
+        "contentHash": "1waeeEEM/Dp5l2laUByEEWfd6qyI00HExDduhLKGT2kPnHArjIDcMf2z9HIjeLPoR56iBHhvXTfAv1hiH/wAAQ==",
+        "dependencies": {
+          "Microsoft.Data.Sqlite.Core": "9.0.10",
+          "SQLitePCLRaw.bundle_e_sqlite3": "2.1.10",
+          "SQLitePCLRaw.core": "2.1.10"
+        }
+      },
+      "Microsoft.Data.Sqlite.Core": {
+        "type": "Transitive",
+        "resolved": "9.0.10",
+        "contentHash": "tWbN2uzG4uBxxMjcHA3Oa9ecAYjyRTfDwRbgQ7ueyx7eEgyYbBiKADY2rllF8wO3dHUvN+/8fgylwSGMfiCtVg==",
+        "dependencies": {
+          "SQLitePCLRaw.core": "2.1.10"
+        }
+      },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "Transitive",
         "resolved": "2.1.1",
@@ -110,10 +128,45 @@
         "resolved": "6.0.7",
         "contentHash": "16kwDY6+/TCBToyXekpcl5mxprUWuXqltdOK26w44E0rTQTiRCjXv1VVLDtSbgMCR1RirVvr+V/9T+76cwuqnw=="
       },
+      "SQLitePCLRaw.bundle_e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "2.1.10",
+        "contentHash": "UxWuisvZ3uVcVOLJQv7urM/JiQH+v3TmaJc1BLKl5Dxfm/nTzTUrqswCqg/INiYLi61AXnHo1M1JPmPqqLnAdg==",
+        "dependencies": {
+          "SQLitePCLRaw.lib.e_sqlite3": "2.1.10",
+          "SQLitePCLRaw.provider.e_sqlite3": "2.1.10"
+        }
+      },
+      "SQLitePCLRaw.core": {
+        "type": "Transitive",
+        "resolved": "2.1.10",
+        "contentHash": "Ii8JCbC7oiVclaE/mbDEK000EFIJ+ShRPwAvvV89GOZhQ+ZLtlnSWl6ksCNMKu/VGXA4Nfi2B7LhN/QFN9oBcw==",
+        "dependencies": {
+          "System.Memory": "4.5.3"
+        }
+      },
+      "SQLitePCLRaw.lib.e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "2.1.10",
+        "contentHash": "mAr69tDbnf3QJpRy2nJz8Qdpebdil00fvycyByR58Cn9eARvR+UiG2Vzsp+4q1tV3ikwiYIjlXCQFc12GfebbA=="
+      },
+      "SQLitePCLRaw.provider.e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "2.1.10",
+        "contentHash": "uZVTi02C1SxqzgT0HqTWatIbWGb40iIkfc3FpFCpE/r7g6K0PqzDUeefL6P6HPhDtc6BacN3yQysfzP7ks+wSQ==",
+        "dependencies": {
+          "SQLitePCLRaw.core": "2.1.10"
+        }
+      },
       "Std.UriTemplate": {
         "type": "Transitive",
         "resolved": "2.0.8",
         "contentHash": "IAR4gJlLVD4r/FsU/rDb1+9sbB3/tCFVZz5IzlbM2yHoiUisBi5Ek/KXRUF7RcqNARka79EoaOz9INnXvQ/O6w=="
+      },
+      "System.Memory": {
+        "type": "Transitive",
+        "resolved": "4.5.3",
+        "contentHash": "3oDzvc/zzetpTKWMShs1AADwZjQ/36HnsufHRPcOjyRAAMLDlu2iD33MBI2opxnezcVUtXyqDXXjoFMOU9c7SA=="
       },
       "System.Text.Encoding.CodePages": {
         "type": "Transitive",
@@ -159,6 +212,7 @@
           "DcsTranslationTool.Domain": "[1.0.0, )",
           "DcsTranslationTool.Shared": "[1.0.0, )",
           "FluentResults": "[4.0.0, )",
+          "Microsoft.Data.Sqlite": "[9.0.10, )",
           "Microsoft.Kiota.Abstractions": "[1.21.2, )",
           "Microsoft.Kiota.Http.HttpClientLibrary": "[1.21.2, )",
           "Microsoft.Kiota.Serialization.Form": "[1.21.2, )",
@@ -177,6 +231,11 @@
       }
     },
     "net8.0-windows7.0/win-x64": {
+      "SQLitePCLRaw.lib.e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "2.1.10",
+        "contentHash": "mAr69tDbnf3QJpRy2nJz8Qdpebdil00fvycyByR58Cn9eARvR+UiG2Vzsp+4q1tV3ikwiYIjlXCQFc12GfebbA=="
+      },
       "System.Text.Encoding.CodePages": {
         "type": "Transitive",
         "resolved": "8.0.0",
@@ -184,6 +243,11 @@
       }
     },
     "net8.0-windows7.0/win-x86": {
+      "SQLitePCLRaw.lib.e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "2.1.10",
+        "contentHash": "mAr69tDbnf3QJpRy2nJz8Qdpebdil00fvycyByR58Cn9eARvR+UiG2Vzsp+4q1tV3ikwiYIjlXCQFc12GfebbA=="
+      },
       "System.Text.Encoding.CodePages": {
         "type": "Transitive",
         "resolved": "8.0.0",

--- a/tests/DcsTranslationTool.Composition.Tests/CompositionRegistrationTests.cs
+++ b/tests/DcsTranslationTool.Composition.Tests/CompositionRegistrationTests.cs
@@ -22,8 +22,11 @@ public class CompositionRegistrationTests {
         // Act
         var loggingService = container.GetInstance( typeof( ILoggingService ), null );
         var appSettingsService = container.GetInstance( typeof( IAppSettingsService ), null );
+        var treeHttpClientProvider = container.GetInstance( typeof( ITreeHttpClientProvider ), null );
         var apiService1 = container.GetInstance( typeof( IApiService ), null );
         var apiService2 = container.GetInstance( typeof( IApiService ), null );
+        var hashCacheService1 = container.GetInstance( typeof( IFileEntryHashCacheService ), null );
+        var hashCacheService2 = container.GetInstance( typeof( IFileEntryHashCacheService ), null );
         var updateCheckService = container.GetInstance( typeof( IUpdateCheckService ), null );
         var zipService1 = container.GetInstance( typeof( IZipService ), null );
         var zipService2 = container.GetInstance( typeof( IZipService ), null );
@@ -32,8 +35,11 @@ public class CompositionRegistrationTests {
         Assert.NotNull( loggingService );
         Assert.IsType<LoggingService>( loggingService );
         context.TrackedAppSettings = Assert.IsType<AppSettingsService>( appSettingsService );
+        Assert.IsType<TreeHttpClientProvider>( treeHttpClientProvider );
         Assert.Same( apiService1, apiService2 );
         Assert.IsType<ApiService>( apiService1 );
+        Assert.Same( hashCacheService1, hashCacheService2 );
+        Assert.IsType<FileEntryHashCacheService>( hashCacheService1 );
         Assert.IsType<UpdateCheckService>( updateCheckService );
         Assert.Same( zipService1, zipService2 );
         Assert.NotNull( NLogManager.Configuration );

--- a/tests/DcsTranslationTool.Composition.Tests/packages.lock.json
+++ b/tests/DcsTranslationTool.Composition.Tests/packages.lock.json
@@ -91,6 +91,24 @@
         "resolved": "18.0.1",
         "contentHash": "O+utSr97NAJowIQT/OVp3Lh9QgW/wALVTP4RG1m2AfFP4IyJmJz0ZBmFJUsRQiAPgq6IRC0t8AAzsiPIsaUDEA=="
       },
+      "Microsoft.Data.Sqlite": {
+        "type": "Transitive",
+        "resolved": "9.0.10",
+        "contentHash": "1waeeEEM/Dp5l2laUByEEWfd6qyI00HExDduhLKGT2kPnHArjIDcMf2z9HIjeLPoR56iBHhvXTfAv1hiH/wAAQ==",
+        "dependencies": {
+          "Microsoft.Data.Sqlite.Core": "9.0.10",
+          "SQLitePCLRaw.bundle_e_sqlite3": "2.1.10",
+          "SQLitePCLRaw.core": "2.1.10"
+        }
+      },
+      "Microsoft.Data.Sqlite.Core": {
+        "type": "Transitive",
+        "resolved": "9.0.10",
+        "contentHash": "tWbN2uzG4uBxxMjcHA3Oa9ecAYjyRTfDwRbgQ7ueyx7eEgyYbBiKADY2rllF8wO3dHUvN+/8fgylwSGMfiCtVg==",
+        "dependencies": {
+          "SQLitePCLRaw.core": "2.1.10"
+        }
+      },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "Transitive",
         "resolved": "2.1.1",
@@ -226,6 +244,36 @@
         "resolved": "6.0.7",
         "contentHash": "16kwDY6+/TCBToyXekpcl5mxprUWuXqltdOK26w44E0rTQTiRCjXv1VVLDtSbgMCR1RirVvr+V/9T+76cwuqnw=="
       },
+      "SQLitePCLRaw.bundle_e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "2.1.10",
+        "contentHash": "UxWuisvZ3uVcVOLJQv7urM/JiQH+v3TmaJc1BLKl5Dxfm/nTzTUrqswCqg/INiYLi61AXnHo1M1JPmPqqLnAdg==",
+        "dependencies": {
+          "SQLitePCLRaw.lib.e_sqlite3": "2.1.10",
+          "SQLitePCLRaw.provider.e_sqlite3": "2.1.10"
+        }
+      },
+      "SQLitePCLRaw.core": {
+        "type": "Transitive",
+        "resolved": "2.1.10",
+        "contentHash": "Ii8JCbC7oiVclaE/mbDEK000EFIJ+ShRPwAvvV89GOZhQ+ZLtlnSWl6ksCNMKu/VGXA4Nfi2B7LhN/QFN9oBcw==",
+        "dependencies": {
+          "System.Memory": "4.5.3"
+        }
+      },
+      "SQLitePCLRaw.lib.e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "2.1.10",
+        "contentHash": "mAr69tDbnf3QJpRy2nJz8Qdpebdil00fvycyByR58Cn9eARvR+UiG2Vzsp+4q1tV3ikwiYIjlXCQFc12GfebbA=="
+      },
+      "SQLitePCLRaw.provider.e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "2.1.10",
+        "contentHash": "uZVTi02C1SxqzgT0HqTWatIbWGb40iIkfc3FpFCpE/r7g6K0PqzDUeefL6P6HPhDtc6BacN3yQysfzP7ks+wSQ==",
+        "dependencies": {
+          "SQLitePCLRaw.core": "2.1.10"
+        }
+      },
       "Std.UriTemplate": {
         "type": "Transitive",
         "resolved": "2.0.8",
@@ -245,6 +293,11 @@
         "type": "Transitive",
         "resolved": "6.0.0",
         "contentHash": "lcyUiXTsETK2ALsZrX+nWuHSIQeazhqPphLfaRxzdGaG93+0kELqpgEHtwWOlQe7+jSFnKwaCAgL4kjeZCQJnw=="
+      },
+      "System.Memory": {
+        "type": "Transitive",
+        "resolved": "4.5.3",
+        "contentHash": "3oDzvc/zzetpTKWMShs1AADwZjQ/36HnsufHRPcOjyRAAMLDlu2iD33MBI2opxnezcVUtXyqDXXjoFMOU9c7SA=="
       },
       "System.Reflection.Metadata": {
         "type": "Transitive",
@@ -379,6 +432,7 @@
           "DcsTranslationTool.Domain": "[1.0.0, )",
           "DcsTranslationTool.Shared": "[1.0.0, )",
           "FluentResults": "[4.0.0, )",
+          "Microsoft.Data.Sqlite": "[9.0.10, )",
           "Microsoft.Kiota.Abstractions": "[1.21.2, )",
           "Microsoft.Kiota.Http.HttpClientLibrary": "[1.21.2, )",
           "Microsoft.Kiota.Serialization.Form": "[1.21.2, )",

--- a/tests/DcsTranslationTool.Infrastructure.Tests/Services/FileEntryHashCacheServiceTests.cs
+++ b/tests/DcsTranslationTool.Infrastructure.Tests/Services/FileEntryHashCacheServiceTests.cs
@@ -1,0 +1,123 @@
+using DcsTranslationTool.Infrastructure.Interfaces;
+using DcsTranslationTool.Infrastructure.Services;
+
+using Moq;
+
+namespace DcsTranslationTool.Infrastructure.Tests.Services;
+
+/// <summary>
+/// <see cref="FileEntryHashCacheService"/> の永続化挙動を検証する。
+/// </summary>
+public sealed class FileEntryHashCacheServiceTests : IDisposable {
+    private readonly Mock<ILoggingService> _logger = new();
+    private readonly string _tempDir;
+    private readonly string _preferredBaseDir;
+    private readonly string _fallbackBaseDir;
+
+    public FileEntryHashCacheServiceTests() {
+        _tempDir = Path.Combine( Path.GetTempPath(), $"FileEntryHashCacheServiceTests_{Guid.NewGuid():N}" );
+        _preferredBaseDir = Path.Combine( _tempDir, "preferred" );
+        _fallbackBaseDir = Path.Combine( _tempDir, "fallback" );
+        Directory.CreateDirectory( _tempDir );
+    }
+
+    public void Dispose() {
+        if(Directory.Exists( _tempDir )) {
+            Directory.Delete( _tempDir, true );
+        }
+        GC.SuppressFinalize( this );
+    }
+
+    [Fact]
+    public void Upsertした値は再初期化後も取得できる() {
+        var lastWriteUtc = DateTime.UtcNow.AddMinutes( -1 );
+        const string relativePath = "DCSWorld/Mods/aircraft/A10C/L10N/Test.lua";
+        const string sha = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+        using(var service = CreateService()) {
+            service.ConfigureRoot( _tempDir );
+            service.Upsert( relativePath, 123, lastWriteUtc, sha );
+        }
+
+        using var verifyService = CreateService();
+        verifyService.ConfigureRoot( _tempDir );
+        var hit = verifyService.TryGetSha( relativePath, 123, lastWriteUtc, out var actualSha );
+
+        Assert.True( hit );
+        Assert.Equal( sha, actualSha );
+        var expectedDbPath = Path.Combine( _preferredBaseDir, ".dcs-translation-cache", "hashcache.db" );
+        Assert.True( File.Exists( expectedDbPath ) );
+    }
+
+    [Fact]
+    public void Pruneは存在しないキーを削除する() {
+        var lastWriteUtc = DateTime.UtcNow.AddMinutes( -1 );
+        const string keepPath = "DCSWorld/Mods/aircraft/A10C/L10N/Keep.lua";
+        const string removePath = "DCSWorld/Mods/aircraft/A10C/L10N/Remove.lua";
+
+        using var service = CreateService();
+        service.ConfigureRoot( _tempDir );
+        service.Upsert( keepPath, 1, lastWriteUtc, "1111111111111111111111111111111111111111" );
+        service.Upsert( removePath, 2, lastWriteUtc, "2222222222222222222222222222222222222222" );
+
+        service.Prune( new HashSet<string>( [keepPath], StringComparer.OrdinalIgnoreCase ) );
+
+        var keepHit = service.TryGetSha( keepPath, 1, lastWriteUtc, out _ );
+        var removeHit = service.TryGetSha( removePath, 2, lastWriteUtc, out _ );
+
+        Assert.True( keepHit );
+        Assert.False( removeHit );
+    }
+
+    [Fact]
+    public void 優先保存先に作成できない場合はフォールバック先へ保存する() {
+        var blockedPath = Path.Combine( _tempDir, "blocked" );
+        File.WriteAllText( blockedPath, "blocked" );
+        var root = Path.Combine( _tempDir, "root" );
+        Directory.CreateDirectory( root );
+
+        var lastWriteUtc = DateTime.UtcNow.AddMinutes( -1 );
+        const string relativePath = "DCSWorld/Mods/aircraft/A10C/L10N/Fallback.lua";
+
+        using var service = new FileEntryHashCacheService( _logger.Object, blockedPath, _fallbackBaseDir );
+        service.ConfigureRoot( root );
+        service.Upsert( relativePath, 1, lastWriteUtc, "3333333333333333333333333333333333333333" );
+
+        var fallbackDbPath = Path.Combine( _fallbackBaseDir, "cache", "hashcache.db" );
+        Assert.True( File.Exists( fallbackDbPath ) );
+    }
+
+    [Fact]
+    public void ルートを切り替えても他ルートのSHAを誤って再利用しない() {
+        var rootA = Path.Combine( _tempDir, "rootA" );
+        var rootB = Path.Combine( _tempDir, "rootB" );
+        Directory.CreateDirectory( rootA );
+        Directory.CreateDirectory( rootB );
+
+        var lastWriteUtc = new DateTime( 2026, 1, 1, 0, 0, 0, DateTimeKind.Utc );
+        const string relativePath = "DCSWorld/Mods/aircraft/A10C/L10N/Common.lua";
+        const string shaA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+        using var service = CreateService();
+        service.ConfigureRoot( rootA );
+        service.Upsert( relativePath, 100, lastWriteUtc, shaA );
+
+        service.ConfigureRoot( rootB );
+        var hitOnRootB = service.TryGetSha( relativePath, 100, lastWriteUtc, out var shaOnRootB );
+
+        service.ConfigureRoot( rootA );
+        var hitOnRootA = service.TryGetSha( relativePath, 100, lastWriteUtc, out var shaOnRootA );
+
+        Assert.False( hitOnRootB );
+        Assert.Null( shaOnRootB );
+        Assert.True( hitOnRootA );
+        Assert.Equal( shaA, shaOnRootA );
+    }
+
+    /// <summary>
+    /// テスト対象サービスを生成する。
+    /// </summary>
+    /// <returns>生成したキャッシュサービス。</returns>
+    private FileEntryHashCacheService CreateService() =>
+        new( _logger.Object, _preferredBaseDir, _fallbackBaseDir );
+}

--- a/tests/DcsTranslationTool.Infrastructure.Tests/Services/FileEntryServiceTests.cs
+++ b/tests/DcsTranslationTool.Infrastructure.Tests/Services/FileEntryServiceTests.cs
@@ -1,3 +1,4 @@
+using DcsTranslationTool.Application.Interfaces;
 using DcsTranslationTool.Application.Results;
 using DcsTranslationTool.Infrastructure.Interfaces;
 using DcsTranslationTool.Infrastructure.Services;
@@ -9,6 +10,7 @@ namespace DcsTranslationTool.Infrastructure.Tests.Services;
 
 public class FileEntryServiceTests : IDisposable {
     private readonly Mock<ILoggingService> logger = new();
+    private readonly Mock<IFileEntryHashCacheService> _hashCacheService = new();
     private readonly string _tempDir;
 
     public FileEntryServiceTests() {
@@ -31,7 +33,7 @@ public class FileEntryServiceTests : IDisposable {
 
         var filePath = Path.Combine(targetSubdir, "test.txt");
         File.WriteAllText( filePath, "Hello World" );
-        var service = new FileEntryService(logger.Object);
+        var service = CreateService();
 
         // Act
         var result = await service.GetChildrenRecursiveAsync(targetDir);
@@ -55,7 +57,7 @@ public class FileEntryServiceTests : IDisposable {
         // Arrange
         var targetDir = Path.Combine(_tempDir, "EmptyDir_" + Guid.NewGuid());
         Directory.CreateDirectory( targetDir );
-        var service = new FileEntryService(logger.Object);
+        var service = CreateService();
 
         // Act
         var result = await service.GetChildrenRecursiveAsync(targetDir);
@@ -70,7 +72,7 @@ public class FileEntryServiceTests : IDisposable {
     public async Task GetChildrenRecursiveは存在しないパスを指定した場合失敗結果を返す() {
         // Arrange
         var invalidPath = Path.Combine(_tempDir, "NotExist_" + Guid.NewGuid());
-        var service = new FileEntryService(logger.Object);
+        var service = CreateService();
 
         // Act
         var result = await service.GetChildrenRecursiveAsync(invalidPath);
@@ -79,7 +81,52 @@ public class FileEntryServiceTests : IDisposable {
         Assert.True( result.IsFailed );
         var actualMessage = result.Errors[0].Message;
         Assert.StartsWith( "指定されたパスが存在しません: ", actualMessage );
-        Assert.Equal( ResultErrorKind.NotFound.ToString(), result.Errors[0].Metadata["kind"] );
+        Assert.Equal( nameof( ResultErrorKind.NotFound ), result.Errors[0].Metadata["kind"] );
+    }
+
+    [Fact]
+    public async Task GetChildrenRecursiveはWatch未実行でもハッシュキャッシュ初期化後に成功する() {
+        // Arrange
+        var targetDir = Path.Combine( _tempDir, "DirectRecursiveWithRealCache" );
+        Directory.CreateDirectory( targetDir );
+        var filePath = Path.Combine( targetDir, "test.txt" );
+        await File.WriteAllTextAsync( filePath, "Hello", TestContext.Current.CancellationToken );
+
+        var preferredBaseDir = Path.Combine( _tempDir, "cache-preferred" );
+        var fallbackBaseDir = Path.Combine( _tempDir, "cache-fallback" );
+        var hashCacheService = new FileEntryHashCacheService( logger.Object, preferredBaseDir, fallbackBaseDir );
+        using var service = new FileEntryService( logger.Object, hashCacheService );
+
+        // Act
+        var result = await service.GetChildrenRecursiveAsync( targetDir );
+
+        // Assert
+        Assert.True( result.IsSuccess );
+        var entries = result.Value.ToArray();
+        Assert.Single( entries );
+        Assert.Equal( "test.txt", entries[0].Path );
+        Assert.NotNull( entries[0].LocalSha );
+    }
+
+    [Fact]
+    public async Task GetChildrenRecursiveはハッシュキャッシュ初期化失敗時に失敗結果を返す() {
+        // Arrange
+        var targetDir = Path.Combine( _tempDir, "CacheInitFailure" );
+        Directory.CreateDirectory( targetDir );
+        var filePath = Path.Combine( targetDir, "test.txt" );
+        await File.WriteAllTextAsync( filePath, "Hello", TestContext.Current.CancellationToken );
+        _hashCacheService
+            .Setup( service => service.ConfigureRoot( targetDir ) )
+            .Throws( new InvalidOperationException( "cache init failed" ) );
+        using var service = CreateService();
+
+        // Act
+        var result = await service.GetChildrenRecursiveAsync( targetDir );
+
+        // Assert
+        Assert.True( result.IsFailed );
+        Assert.Equal( nameof( ResultErrorKind.Unexpected ), result.Errors[0].Metadata["kind"] );
+        Assert.Equal( "FILE_ENTRY_CACHE_INIT_EXCEPTION", result.Errors[0].Metadata["code"] );
     }
 
     #endregion
@@ -91,7 +138,7 @@ public class FileEntryServiceTests : IDisposable {
         // Arrange
         var targetDir = Path.Combine(_tempDir, "WatchDir");
         Directory.CreateDirectory( targetDir );
-        using var service = new FileEntryService(logger.Object);
+        using var service = CreateService();
         var tcs = new TaskCompletionSource<IReadOnlyList<FileEntry>>(TaskCreationOptions.RunContinuationsAsynchronously);
         service.EntriesChanged += entries => {
             if(entries is { Count: > 0 } && entries.All( e => e.LocalSha is not null ))
@@ -115,6 +162,41 @@ public class FileEntryServiceTests : IDisposable {
         Assert.Equal( "6320cd248dd8aeaab759d5871f8781b5c0505172", entry.LocalSha );
     }
 
+    [Fact]
+    public async Task Watchはハッシュキャッシュ初期化失敗時でも監視を継続する() {
+        // Arrange
+        var targetDir = Path.Combine( _tempDir, "WatchWithCacheInitFailure" );
+        Directory.CreateDirectory( targetDir );
+        _hashCacheService
+            .Setup( service => service.ConfigureRoot( targetDir ) )
+            .Throws( new InvalidOperationException( "cache init failed" ) );
+        using var service = CreateService();
+
+        var tcs = new TaskCompletionSource<IReadOnlyList<FileEntry>>( TaskCreationOptions.RunContinuationsAsynchronously );
+        service.EntriesChanged += entries => {
+            if(entries is { Count: > 0 } && entries.All( entry => entry.LocalSha is not null )) {
+                tcs.TrySetResult( entries );
+            }
+
+            return Task.CompletedTask;
+        };
+
+        // Act
+        service.Watch( targetDir );
+        await Task.Delay( 100, TestContext.Current.CancellationToken );
+        var filePath = Path.Combine( targetDir, "new.txt" );
+        await File.WriteAllTextAsync( filePath, "data", TestContext.Current.CancellationToken );
+        var entries = await tcs.Task.WaitAsync( TimeSpan.FromSeconds( 5 ), TestContext.Current.CancellationToken );
+
+        // Assert
+        Assert.Single( entries );
+        Assert.Equal( "new.txt", entries[0].Name );
+        Assert.Equal( "6320cd248dd8aeaab759d5871f8781b5c0505172", entries[0].LocalSha );
+        _hashCacheService.Verify( service => service.TryGetSha( It.IsAny<string>(), It.IsAny<long>(), It.IsAny<DateTime>(), out It.Ref<string?>.IsAny ), Times.Never );
+        _hashCacheService.Verify( service => service.Upsert( It.IsAny<string>(), It.IsAny<long>(), It.IsAny<DateTime>(), It.IsAny<string?>() ), Times.Never );
+        _hashCacheService.Verify( service => service.Prune( It.IsAny<IReadOnlySet<string>>() ), Times.Never );
+    }
+
     #endregion
 
     #region GetEntriesAsync
@@ -122,7 +204,7 @@ public class FileEntryServiceTests : IDisposable {
     [Fact]
     public async Task GetEntriesAsyncはWatch未実行で空のコレクションを返す() {
         // Arrange
-        using var service = new FileEntryService(logger.Object);
+        using var service = CreateService();
 
         // Act
         var result = await service.GetEntriesAsync();
@@ -136,7 +218,7 @@ public class FileEntryServiceTests : IDisposable {
     public async Task Watchは存在しないディレクトリを指定したときGetEntriesAsyncが失敗結果を返す() {
         // Arrange
         var targetDir = Path.Combine(_tempDir, "NotExistDir");
-        using var service = new FileEntryService(logger.Object);
+        using var service = CreateService();
 
         // Act
         service.Watch( targetDir );
@@ -147,4 +229,11 @@ public class FileEntryServiceTests : IDisposable {
     }
 
     #endregion
+
+    /// <summary>
+    /// テスト対象サービスを生成する。
+    /// </summary>
+    /// <returns>初期化済みの <see cref="FileEntryService"/> を返す。</returns>
+    private FileEntryService CreateService() =>
+        new( logger.Object, _hashCacheService.Object );
 }

--- a/tests/DcsTranslationTool.Infrastructure.Tests/TestDoubles/NoOpLoggingService.cs
+++ b/tests/DcsTranslationTool.Infrastructure.Tests/TestDoubles/NoOpLoggingService.cs
@@ -1,0 +1,24 @@
+using DcsTranslationTool.Infrastructure.Interfaces;
+
+namespace DcsTranslationTool.Infrastructure.Tests.TestDoubles;
+
+/// <summary>
+/// 何も出力しないテスト用ロガーを提供する。
+/// </summary>
+public sealed class NoOpLoggingService : ILoggingService {
+    public static ILoggingService Instance { get; } = new NoOpLoggingService();
+
+    private NoOpLoggingService() { }
+
+    public void Trace( string message, Exception? ex = null, string? member = null, string? file = null, int line = 0 ) { }
+
+    public void Debug( string message, Exception? ex = null, string? member = null, string? file = null, int line = 0 ) { }
+
+    public void Info( string message, Exception? ex = null, string? member = null, string? file = null, int line = 0 ) { }
+
+    public void Warn( string message, Exception? ex = null, string? member = null, string? file = null, int line = 0 ) { }
+
+    public void Error( string message, Exception? ex = null, string? member = null, string? file = null, int line = 0 ) { }
+
+    public void Fatal( string message, Exception? ex = null, string? member = null, string? file = null, int line = 0 ) { }
+}

--- a/tests/DcsTranslationTool.Infrastructure.Tests/packages.lock.json
+++ b/tests/DcsTranslationTool.Infrastructure.Tests/packages.lock.json
@@ -77,6 +77,24 @@
         "resolved": "18.0.1",
         "contentHash": "O+utSr97NAJowIQT/OVp3Lh9QgW/wALVTP4RG1m2AfFP4IyJmJz0ZBmFJUsRQiAPgq6IRC0t8AAzsiPIsaUDEA=="
       },
+      "Microsoft.Data.Sqlite": {
+        "type": "Transitive",
+        "resolved": "9.0.10",
+        "contentHash": "1waeeEEM/Dp5l2laUByEEWfd6qyI00HExDduhLKGT2kPnHArjIDcMf2z9HIjeLPoR56iBHhvXTfAv1hiH/wAAQ==",
+        "dependencies": {
+          "Microsoft.Data.Sqlite.Core": "9.0.10",
+          "SQLitePCLRaw.bundle_e_sqlite3": "2.1.10",
+          "SQLitePCLRaw.core": "2.1.10"
+        }
+      },
+      "Microsoft.Data.Sqlite.Core": {
+        "type": "Transitive",
+        "resolved": "9.0.10",
+        "contentHash": "tWbN2uzG4uBxxMjcHA3Oa9ecAYjyRTfDwRbgQ7ueyx7eEgyYbBiKADY2rllF8wO3dHUvN+/8fgylwSGMfiCtVg==",
+        "dependencies": {
+          "SQLitePCLRaw.core": "2.1.10"
+        }
+      },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "Transitive",
         "resolved": "2.1.1",
@@ -207,6 +225,36 @@
         "resolved": "6.0.7",
         "contentHash": "16kwDY6+/TCBToyXekpcl5mxprUWuXqltdOK26w44E0rTQTiRCjXv1VVLDtSbgMCR1RirVvr+V/9T+76cwuqnw=="
       },
+      "SQLitePCLRaw.bundle_e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "2.1.10",
+        "contentHash": "UxWuisvZ3uVcVOLJQv7urM/JiQH+v3TmaJc1BLKl5Dxfm/nTzTUrqswCqg/INiYLi61AXnHo1M1JPmPqqLnAdg==",
+        "dependencies": {
+          "SQLitePCLRaw.lib.e_sqlite3": "2.1.10",
+          "SQLitePCLRaw.provider.e_sqlite3": "2.1.10"
+        }
+      },
+      "SQLitePCLRaw.core": {
+        "type": "Transitive",
+        "resolved": "2.1.10",
+        "contentHash": "Ii8JCbC7oiVclaE/mbDEK000EFIJ+ShRPwAvvV89GOZhQ+ZLtlnSWl6ksCNMKu/VGXA4Nfi2B7LhN/QFN9oBcw==",
+        "dependencies": {
+          "System.Memory": "4.5.3"
+        }
+      },
+      "SQLitePCLRaw.lib.e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "2.1.10",
+        "contentHash": "mAr69tDbnf3QJpRy2nJz8Qdpebdil00fvycyByR58Cn9eARvR+UiG2Vzsp+4q1tV3ikwiYIjlXCQFc12GfebbA=="
+      },
+      "SQLitePCLRaw.provider.e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "2.1.10",
+        "contentHash": "uZVTi02C1SxqzgT0HqTWatIbWGb40iIkfc3FpFCpE/r7g6K0PqzDUeefL6P6HPhDtc6BacN3yQysfzP7ks+wSQ==",
+        "dependencies": {
+          "SQLitePCLRaw.core": "2.1.10"
+        }
+      },
       "Std.UriTemplate": {
         "type": "Transitive",
         "resolved": "2.0.8",
@@ -226,6 +274,11 @@
         "type": "Transitive",
         "resolved": "6.0.0",
         "contentHash": "lcyUiXTsETK2ALsZrX+nWuHSIQeazhqPphLfaRxzdGaG93+0kELqpgEHtwWOlQe7+jSFnKwaCAgL4kjeZCQJnw=="
+      },
+      "System.Memory": {
+        "type": "Transitive",
+        "resolved": "4.5.3",
+        "contentHash": "3oDzvc/zzetpTKWMShs1AADwZjQ/36HnsufHRPcOjyRAAMLDlu2iD33MBI2opxnezcVUtXyqDXXjoFMOU9c7SA=="
       },
       "System.Reflection.Metadata": {
         "type": "Transitive",
@@ -352,6 +405,7 @@
           "DcsTranslationTool.Domain": "[1.0.0, )",
           "DcsTranslationTool.Shared": "[1.0.0, )",
           "FluentResults": "[4.0.0, )",
+          "Microsoft.Data.Sqlite": "[9.0.10, )",
           "Microsoft.Kiota.Abstractions": "[1.21.2, )",
           "Microsoft.Kiota.Http.HttpClientLibrary": "[1.21.2, )",
           "Microsoft.Kiota.Serialization.Form": "[1.21.2, )",

--- a/tests/DcsTranslationTool.Presentation.Wpf.Tests/BootstrapperContainerTests.cs
+++ b/tests/DcsTranslationTool.Presentation.Wpf.Tests/BootstrapperContainerTests.cs
@@ -105,7 +105,9 @@ public sealed class BootstrapperContainerTests {
         public void AssertResolutions() {
             Assert.IsType<LoggingService>( Get<ILoggingService>() );
             Assert.IsType<AppSettingsService>( Get<IAppSettingsService>() );
+            Assert.IsType<TreeHttpClientProvider>( Get<ITreeHttpClientProvider>() );
             Assert.IsType<ApiService>( Get<IApiService>() );
+            Assert.IsType<FileEntryHashCacheService>( Get<IFileEntryHashCacheService>() );
             Assert.IsType<FileEntryService>( Get<IFileEntryService>() );
             Assert.IsType<FileService>( Get<IFileService>() );
             Assert.IsType<FileContentInspector>( Get<IFileContentInspector>() );

--- a/tests/DcsTranslationTool.Presentation.Wpf.Tests/Features/CreatePullRequest/CreatePullRequestViewModelTests.cs
+++ b/tests/DcsTranslationTool.Presentation.Wpf.Tests/Features/CreatePullRequest/CreatePullRequestViewModelTests.cs
@@ -7,7 +7,6 @@ using DcsTranslationTool.Application.Enums;
 using DcsTranslationTool.Application.Interfaces;
 using DcsTranslationTool.Application.Models;
 using DcsTranslationTool.Presentation.Wpf.Features.CreatePullRequest;
-using DcsTranslationTool.Presentation.Wpf.Services;
 using DcsTranslationTool.Presentation.Wpf.UI.Dialogs.Parameters;
 using DcsTranslationTool.Presentation.Wpf.UI.Enums;
 using DcsTranslationTool.Shared.Models;

--- a/tests/DcsTranslationTool.Presentation.Wpf.Tests/Features/Settings/SettingsViewModelTests.cs
+++ b/tests/DcsTranslationTool.Presentation.Wpf.Tests/Features/Settings/SettingsViewModelTests.cs
@@ -2,7 +2,6 @@ using Caliburn.Micro;
 
 using DcsTranslationTool.Application.Interfaces;
 using DcsTranslationTool.Presentation.Wpf.Features.Settings;
-using DcsTranslationTool.Presentation.Wpf.Services;
 using DcsTranslationTool.Presentation.Wpf.Services.Abstractions;
 using DcsTranslationTool.Shared.Models;
 

--- a/tests/DcsTranslationTool.Presentation.Wpf.Tests/Services/ApplicationInfoServiceTests.cs
+++ b/tests/DcsTranslationTool.Presentation.Wpf.Tests/Services/ApplicationInfoServiceTests.cs
@@ -2,8 +2,6 @@ using DcsTranslationTool.Presentation.Wpf.Services;
 
 using Moq;
 
-using Xunit;
-
 namespace DcsTranslationTool.Presentation.Wpf.Tests.Services;
 
 public sealed class ApplicationInfoServiceTests {

--- a/tests/DcsTranslationTool.Presentation.Wpf.Tests/Services/FileEntryTreeServiceTests.cs
+++ b/tests/DcsTranslationTool.Presentation.Wpf.Tests/Services/FileEntryTreeServiceTests.cs
@@ -1,0 +1,127 @@
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+
+using DcsTranslationTool.Domain.Models;
+using DcsTranslationTool.Presentation.Wpf.Services;
+using DcsTranslationTool.Presentation.Wpf.UI.Enums;
+using DcsTranslationTool.Presentation.Wpf.ViewModels;
+using DcsTranslationTool.Shared.Models;
+
+using Moq;
+
+namespace DcsTranslationTool.Presentation.Wpf.Tests.Services;
+
+public sealed class FileEntryTreeServiceTests {
+    [Fact]
+    public void ApplyFilterは子ノード列挙中にコレクションが変更されても例外を送出しない() {
+        var logger = new Mock<ILoggingService>();
+        var sut = new FileEntryTreeService( logger.Object );
+        var root = new FileEntryViewModel(
+            new FileEntry( "root", "root", true ),
+            ChangeTypeMode.Upload,
+            logger.Object
+        );
+        var first = new FileEntryViewModel(
+            new FileEntry( "first.lua", "root/first.lua", false, "local-1", "repo-1" ),
+            ChangeTypeMode.Upload,
+            logger.Object
+        );
+        var second = new FileEntryViewModel(
+            new FileEntry( "second.lua", "root/second.lua", false, "local-2", "repo-2" ),
+            ChangeTypeMode.Upload,
+            logger.Object
+        );
+        root.Children.Add( first );
+        root.Children.Add( second );
+        ((INotifyPropertyChanged)first).PropertyChanged += ( _, e ) => {
+            if(e.PropertyName != nameof( FileEntryViewModel.IsVisible )) {
+                return;
+            }
+
+            if(root.Children.Contains( second )) {
+                root.Children.Remove( second );
+            }
+        };
+
+        var tab = new TabItemViewModel( CategoryType.Aircraft, logger.Object, root );
+
+        var exception = Record.Exception( () => sut.ApplyFilter(
+            [tab],
+            [FileChangeType.Modified]
+        ) );
+
+        Assert.Null( exception );
+    }
+
+    [Fact]
+    public void ApplyFilterはタブ列挙中にコレクションが変更されても例外を送出しない() {
+        var logger = new Mock<ILoggingService>();
+        var sut = new FileEntryTreeService( logger.Object );
+        var firstRoot = new FileEntryViewModel(
+            new FileEntry( "first-root", "first-root", true ),
+            ChangeTypeMode.Upload,
+            logger.Object
+        );
+        firstRoot.Children.Add( new FileEntryViewModel(
+            new FileEntry( "first.lua", "first-root/first.lua", false, "local-1", "repo-1" ),
+            ChangeTypeMode.Upload,
+            logger.Object
+        ) );
+        var secondRoot = new FileEntryViewModel(
+            new FileEntry( "second-root", "second-root", true ),
+            ChangeTypeMode.Upload,
+            logger.Object
+        );
+        secondRoot.Children.Add( new FileEntryViewModel(
+            new FileEntry( "second.lua", "second-root/second.lua", false, "local-2", "repo-2" ),
+            ChangeTypeMode.Upload,
+            logger.Object
+        ) );
+        var firstTab = new TabItemViewModel( CategoryType.Aircraft, logger.Object, firstRoot );
+        var secondTab = new TabItemViewModel( CategoryType.DlcCampaigns, logger.Object, secondRoot );
+        var tabs = new ObservableCollection<TabItemViewModel> { firstTab, secondTab };
+        ((INotifyPropertyChanged)firstRoot).PropertyChanged += ( _, e ) => {
+            if(e.PropertyName != nameof( FileEntryViewModel.IsVisible )) {
+                return;
+            }
+
+            tabs.Remove( secondTab );
+        };
+
+        var exception = Record.Exception( () => sut.ApplyFilter(
+            tabs,
+            [FileChangeType.Modified]
+        ) );
+
+        Assert.Null( exception );
+    }
+
+    [Fact]
+    public void BuildTabsは同名のファイルとディレクトリが競合しても別ノードとして構築する() {
+        var logger = new Mock<ILoggingService>();
+        var sut = new FileEntryTreeService( logger.Object );
+        var localEntries = new FileEntry[]
+        {
+            new LocalFileEntry( "A10C", "DCSWorld/Mods/aircraft/A10C", false, "local-a10c-file-sha" )
+        };
+        var repoEntries = new FileEntry[]
+        {
+            new RepoFileEntry( "Example.lua", "DCSWorld/Mods/aircraft/A10C/L10N/Example.lua", false, "repo-example-sha" )
+        };
+
+        var tabs = sut.BuildTabs( localEntries, repoEntries, ChangeTypeMode.Upload );
+        var aircraftRoot = tabs.Single( tab => tab.TabType == CategoryType.Aircraft ).Root;
+        var conflictedNodes = aircraftRoot.Children
+            .Where( child => string.Equals( child.Name, "A10C", StringComparison.Ordinal ) )
+            .ToArray();
+
+        Assert.Equal( 2, conflictedNodes.Length );
+        Assert.Contains( conflictedNodes, node => !node.IsDirectory && node.Path == "DCSWorld/Mods/aircraft/A10C" );
+
+        var directoryNode = Assert.Single( conflictedNodes, node => node.IsDirectory );
+        var l10nNode = Assert.Single( directoryNode.Children, node => node.Name == "L10N" && node.IsDirectory );
+        var exampleNode = Assert.Single( l10nNode.Children, node => node.Name == "Example.lua" && !node.IsDirectory );
+
+        Assert.Equal( "DCSWorld/Mods/aircraft/A10C/L10N/Example.lua", exampleNode.Path );
+    }
+}

--- a/tests/DcsTranslationTool.Presentation.Wpf.Tests/packages.lock.json
+++ b/tests/DcsTranslationTool.Presentation.Wpf.Tests/packages.lock.json
@@ -114,6 +114,24 @@
         "resolved": "18.0.1",
         "contentHash": "O+utSr97NAJowIQT/OVp3Lh9QgW/wALVTP4RG1m2AfFP4IyJmJz0ZBmFJUsRQiAPgq6IRC0t8AAzsiPIsaUDEA=="
       },
+      "Microsoft.Data.Sqlite": {
+        "type": "Transitive",
+        "resolved": "9.0.10",
+        "contentHash": "1waeeEEM/Dp5l2laUByEEWfd6qyI00HExDduhLKGT2kPnHArjIDcMf2z9HIjeLPoR56iBHhvXTfAv1hiH/wAAQ==",
+        "dependencies": {
+          "Microsoft.Data.Sqlite.Core": "9.0.10",
+          "SQLitePCLRaw.bundle_e_sqlite3": "2.1.10",
+          "SQLitePCLRaw.core": "2.1.10"
+        }
+      },
+      "Microsoft.Data.Sqlite.Core": {
+        "type": "Transitive",
+        "resolved": "9.0.10",
+        "contentHash": "tWbN2uzG4uBxxMjcHA3Oa9ecAYjyRTfDwRbgQ7ueyx7eEgyYbBiKADY2rllF8wO3dHUvN+/8fgylwSGMfiCtVg==",
+        "dependencies": {
+          "SQLitePCLRaw.core": "2.1.10"
+        }
+      },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "Transitive",
         "resolved": "2.1.1",
@@ -249,6 +267,36 @@
         "resolved": "6.0.7",
         "contentHash": "16kwDY6+/TCBToyXekpcl5mxprUWuXqltdOK26w44E0rTQTiRCjXv1VVLDtSbgMCR1RirVvr+V/9T+76cwuqnw=="
       },
+      "SQLitePCLRaw.bundle_e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "2.1.10",
+        "contentHash": "UxWuisvZ3uVcVOLJQv7urM/JiQH+v3TmaJc1BLKl5Dxfm/nTzTUrqswCqg/INiYLi61AXnHo1M1JPmPqqLnAdg==",
+        "dependencies": {
+          "SQLitePCLRaw.lib.e_sqlite3": "2.1.10",
+          "SQLitePCLRaw.provider.e_sqlite3": "2.1.10"
+        }
+      },
+      "SQLitePCLRaw.core": {
+        "type": "Transitive",
+        "resolved": "2.1.10",
+        "contentHash": "Ii8JCbC7oiVclaE/mbDEK000EFIJ+ShRPwAvvV89GOZhQ+ZLtlnSWl6ksCNMKu/VGXA4Nfi2B7LhN/QFN9oBcw==",
+        "dependencies": {
+          "System.Memory": "4.5.3"
+        }
+      },
+      "SQLitePCLRaw.lib.e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "2.1.10",
+        "contentHash": "mAr69tDbnf3QJpRy2nJz8Qdpebdil00fvycyByR58Cn9eARvR+UiG2Vzsp+4q1tV3ikwiYIjlXCQFc12GfebbA=="
+      },
+      "SQLitePCLRaw.provider.e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "2.1.10",
+        "contentHash": "uZVTi02C1SxqzgT0HqTWatIbWGb40iIkfc3FpFCpE/r7g6K0PqzDUeefL6P6HPhDtc6BacN3yQysfzP7ks+wSQ==",
+        "dependencies": {
+          "SQLitePCLRaw.core": "2.1.10"
+        }
+      },
       "Std.UriTemplate": {
         "type": "Transitive",
         "resolved": "2.0.8",
@@ -268,6 +316,11 @@
         "type": "Transitive",
         "resolved": "6.0.0",
         "contentHash": "lcyUiXTsETK2ALsZrX+nWuHSIQeazhqPphLfaRxzdGaG93+0kELqpgEHtwWOlQe7+jSFnKwaCAgL4kjeZCQJnw=="
+      },
+      "System.Memory": {
+        "type": "Transitive",
+        "resolved": "4.5.3",
+        "contentHash": "3oDzvc/zzetpTKWMShs1AADwZjQ/36HnsufHRPcOjyRAAMLDlu2iD33MBI2opxnezcVUtXyqDXXjoFMOU9c7SA=="
       },
       "System.Reflection.Metadata": {
         "type": "Transitive",
@@ -402,6 +455,7 @@
           "DcsTranslationTool.Domain": "[1.0.0, )",
           "DcsTranslationTool.Shared": "[1.0.0, )",
           "FluentResults": "[4.0.0, )",
+          "Microsoft.Data.Sqlite": "[9.0.10, )",
           "Microsoft.Kiota.Abstractions": "[1.21.2, )",
           "Microsoft.Kiota.Http.HttpClientLibrary": "[1.21.2, )",
           "Microsoft.Kiota.Serialization.Form": "[1.21.2, )",


### PR DESCRIPTION
## 📌 概要

<!-- このPRの目的・背景を簡潔に書いてください -->
ファイル一覧取得と差分ツリー表示の性能・安定性を改善する。主にローカルSHA計算の永続キャッシュ化、Tree API取得経路の最適化、UIツリー再構築の非同期化を行い、大量ファイル環境での待ち時間と引っ掛かりを軽減する。

## 🛠 変更内容

<!-- このPRで加えた変更をリストアップしてください -->
- Infrastructure
  - SQLiteベースの `FileEntryHashCacheService` と `IFileEntryHashCacheService` を追加し、ルート別SHA1キャッシュを永続化
  - `FileEntryService` を更新し、キャッシュ参照/更新/削除/Prune、並列ハッシュ計算、監視削除イベント連動を追加
  - `ITreeHttpClientProvider` / `TreeHttpClientProvider` を追加
  - `ApiService.GetTreeAsync` を default/IPv4 経路のレース + フェイルオーバー + TTL付き優先経路記憶に対応
- Presentation
  - `FileEntryTabsViewModelBase` のタブ再構築を非同期化し、世代管理による古い更新反映を抑止
  - ローカル一覧の署名比較で差分なし時の再構築を抑制
  - `DownloadView.xaml` / `UploadView.xaml` の `TreeView` に仮想化設定を追加
  - `FileEntryTreeService` のツリー構築処理を内部ノード経由へ最適化
  - `FileEntryViewModel` の `ChangeType` 計算をキャッシュ化
- Composition / Tests
  - DI登録を更新し、新規サービスを解決可能に変更
  - Infrastructure / Presentation の関連テストを追加・更新

## 留意点

<!-- このPRを使用するうえで注意すべきことをリストアップしてください。 -->
<!-- 必要がなければ N/A としてください -->
- ハッシュキャッシュDBを作成できない環境ではフォールバック保存先を使用する。
- `GetTreeAsync` はネットワーク状況に応じて default/IPv4 経路を自動切替するため、ログ上の経路ラベルが実行ごとに変わる場合がある。

Closes #65 