### PR TITLE
fix(shell): Settings遷移時のウィンドウサイズ強制変更を防止

### DIFF
--- a/src/DcsTranslationTool.Presentation.Wpf/Shell/ShellView.xaml.cs
+++ b/src/DcsTranslationTool.Presentation.Wpf/Shell/ShellView.xaml.cs
@@ -31,9 +31,13 @@ public partial class ShellView : Window {
         var desiredSize = MeasureMinimumContentSize( RootLayout );
         var windowChrome = WindowChrome.GetWindowChrome( this );
         var resizeBorderThickness = windowChrome?.ResizeBorderThickness ?? default;
+        var currentWindowSize = new Size(
+            Math.Max( ActualWidth, Width ),
+            Math.Max( ActualHeight, Height ) );
+        var minimumShellSize = CalculateMinimumShellSize( desiredSize, currentWindowSize, resizeBorderThickness );
 
-        MinWidth = desiredSize.Width + resizeBorderThickness.Left + resizeBorderThickness.Right;
-        MinHeight = desiredSize.Height + resizeBorderThickness.Top + resizeBorderThickness.Bottom;
+        MinWidth = minimumShellSize.Width;
+        MinHeight = minimumShellSize.Height;
     }
 
     /// <summary>
@@ -57,5 +61,30 @@ public partial class ShellView : Window {
         }
 
         return desiredSize;
+    }
+
+    /// <summary>
+    /// Shell の最小サイズを現在サイズを上限として算出する。
+    /// </summary>
+    /// <param name="desiredContentSize">コンテンツが要求するサイズ。</param>
+    /// <param name="currentWindowSize">現在のウィンドウサイズ。</param>
+    /// <param name="resizeBorderThickness">リサイズ枠の厚み。</param>
+    /// <returns>ウィンドウへ適用する最小サイズ。</returns>
+    internal static Size CalculateMinimumShellSize( Size desiredContentSize, Size currentWindowSize, Thickness resizeBorderThickness ) {
+        var desiredWindowWidth = Math.Max( 0, desiredContentSize.Width )
+            + resizeBorderThickness.Left
+            + resizeBorderThickness.Right;
+        var desiredWindowHeight = Math.Max( 0, desiredContentSize.Height )
+            + resizeBorderThickness.Top
+            + resizeBorderThickness.Bottom;
+
+        var boundedWindowWidth = currentWindowSize.Width > 0
+            ? Math.Min( desiredWindowWidth, currentWindowSize.Width )
+            : desiredWindowWidth;
+        var boundedWindowHeight = currentWindowSize.Height > 0
+            ? Math.Min( desiredWindowHeight, currentWindowSize.Height )
+            : desiredWindowHeight;
+
+        return new Size( boundedWindowWidth, boundedWindowHeight );
     }
 }


### PR DESCRIPTION
## 📌 概要

<!-- このPRの目的・背景を簡潔に書いてください -->
Settings Page に遷移した際に Shell ウィンドウサイズが強制的に変更される不具合を修正する。  

## 🛠 変更内容

<!-- このPRで加えた変更をリストアップしてください -->
- `ShellView` の最小サイズ更新処理で、無制約計測したコンテンツ要求サイズをそのまま `MinWidth` / `MinHeight` に反映しないように変更する。
- 現在のウィンドウサイズを上限として最小サイズを算出する `CalculateMinimumShellSize` を追加する。
- Settings Page のような縦長コンテンツ表示時でも、ユーザーが調整したウィンドウサイズを強制的に拡大しないようにする。

## 留意点

<!-- このPRを使用するうえで注意すべきことをリストアップしてください。 -->
<!-- 必要がなければ N/A としてください -->
- 変更対象は Shell の最小サイズ計算ロジックのみであり、`ShellWidth` / `ShellHeight` の永続化仕様は変更しない。
- Settings Page の内容やスクロール挙動自体は変更しない。

Closes #94 