### PR TITLE
fix: 翻訳ファイルの出力形式をUTF-8 BOM無しに変更

### DIFF
--- a/src/DcsTranslationTool.Infrastructure/Services/TranslationDictionaryService.cs
+++ b/src/DcsTranslationTool.Infrastructure/Services/TranslationDictionaryService.cs
@@ -20,6 +20,7 @@ public sealed partial class TranslationDictionaryService( ILoggingService logger
     private const string JapaneseDictionaryEntryPath = "l10n/JP/dictionary";
     private const string CsvHeaderLine = "Enabled,Key,Original,Translated";
     private const string ObsoletePoPrefix = "#~ ";
+    private static readonly UTF8Encoding Utf8WithoutBom = new( encoderShouldEmitUTF8Identifier: false );
 
     /// <inheritdoc />
     public Result<TranslationArchiveDictionaries> LoadArchiveDictionaries( string archiveFullPath ) {
@@ -315,7 +316,7 @@ public sealed partial class TranslationDictionaryService( ILoggingService logger
             cancellationToken.ThrowIfCancellationRequested();
             var content = TranslationDictionaryLuaSerializer.Serialize( items );
             ValidateLuaChunk( content, path );
-            await File.WriteAllTextAsync( path, content, Encoding.UTF8, cancellationToken );
+            await File.WriteAllTextAsync( path, content, Utf8WithoutBom, cancellationToken );
             logger.Info( $"dictionary を保存した。Path={path}, Count={items.Count}" );
         }
         catch(OperationCanceledException) {
@@ -367,7 +368,7 @@ public sealed partial class TranslationDictionaryService( ILoggingService logger
                 AppendPoEntry( builder, item );
             }
 
-            await File.WriteAllTextAsync( path, builder.ToString(), Encoding.UTF8, cancellationToken );
+            await File.WriteAllTextAsync( path, builder.ToString(), Utf8WithoutBom, cancellationToken );
             logger.Info( $"PO を保存した。Path={path}, Count={items.Count}" );
         }
         catch(OperationCanceledException) {
@@ -407,7 +408,7 @@ public sealed partial class TranslationDictionaryService( ILoggingService logger
                 builder.Append( '\n' );
             }
 
-            await File.WriteAllTextAsync( path, builder.ToString(), Encoding.UTF8, cancellationToken );
+            await File.WriteAllTextAsync( path, builder.ToString(), Utf8WithoutBom, cancellationToken );
             logger.Info( $"CSV を保存した。Path={path}, Count={items.Count}" );
         }
         catch(OperationCanceledException) {
@@ -439,7 +440,7 @@ public sealed partial class TranslationDictionaryService( ILoggingService logger
             cancellationToken.ThrowIfCancellationRequested();
             var content = TranslationDictionaryLuaSerializer.Serialize( dictionary, translatedByKey );
             ValidateLuaChunk( content, path );
-            await File.WriteAllTextAsync( path, content, Encoding.UTF8, cancellationToken );
+            await File.WriteAllTextAsync( path, content, Utf8WithoutBom, cancellationToken );
             logger.Info( $"dictionary を保存した。Path={path}, Count={dictionary.Items.Count}" );
         }
         catch(OperationCanceledException) {

--- a/tests/DcsTranslationTool.Infrastructure.UnitTests/Services/TranslationDictionaryServiceTests.cs
+++ b/tests/DcsTranslationTool.Infrastructure.UnitTests/Services/TranslationDictionaryServiceTests.cs
@@ -1,4 +1,5 @@
 using System.IO.Compression;
+using System.Text;
 
 using DcsTranslationTool.Application.Interfaces;
 using DcsTranslationTool.Application.Models;
@@ -223,6 +224,7 @@ dictionary = {
 """.ReplaceLineEndings( "\n" ) + "\n",
             content );
         Assert.DoesNotContain( "\r\n", content, StringComparison.Ordinal );
+        AssertFileIsUtf8WithoutBom( path );
     }
 
     [Fact]
@@ -557,6 +559,7 @@ true,key1,o1,t1
 """.ReplaceLineEndings( "\n" ) + "\n",
             content );
         Assert.DoesNotContain( "\r", content, StringComparison.Ordinal );
+        AssertFileIsUtf8WithoutBom( path );
     }
 
     [Fact]
@@ -728,6 +731,7 @@ msgstr "translated"
             content,
             StringComparison.Ordinal );
         Assert.DoesNotContain( "\r", content, StringComparison.Ordinal );
+        AssertFileIsUtf8WithoutBom( path );
     }
 
     [Fact]
@@ -860,6 +864,17 @@ msgstr ""
         var path = Path.Combine( _tempDirectory, $"{Guid.NewGuid():N}.csv" );
         File.WriteAllText( path, content.ReplaceLineEndings( "\n" ) );
         return path;
+    }
+
+    /// <summary>
+    /// 指定ファイルが UTF-8 BOM なしで保存されていることを検証する。
+    /// </summary>
+    /// <param name="path">検証対象のファイルパス。</param>
+    private static void AssertFileIsUtf8WithoutBom( string path ) {
+        var bytes = File.ReadAllBytes( path );
+        var utf8Bom = Encoding.UTF8.Preamble;
+
+        Assert.True( bytes.Length < utf8Bom.Length || !bytes.AsSpan( 0, utf8Bom.Length ).SequenceEqual( utf8Bom ) );
     }
 
     public void Dispose() {


### PR DESCRIPTION
## 📌 概要

<!-- このPRの目的・背景を簡潔に書いてください -->
翻訳機能で出力する dictionary ファイルのフォーマットがUTF-8 BOM有りになっており、そのままではDCSに取り込めない形式になっていた。

## 🛠 変更内容

<!-- このPRで加えた変更をリストアップしてください -->
- dictionaryの出力形式をUTF-8 BOM無しに変更

## 留意点

<!-- このPRを使用するうえで注意すべきことをリストアップしてください。 -->
<!-- 必要がなければ N/A としてください -->
N/A

Closes #104 