### PR TITLE
fix(translation): 詳細テキストボックスでもCtrl+矢印で選択移動できるように修正

### DIFF
--- a/src/DcsTranslationTool.Presentation.Wpf/Features/TranslationCreation/TranslationCreationView.xaml
+++ b/src/DcsTranslationTool.Presentation.Wpf/Features/TranslationCreation/TranslationCreationView.xaml
@@ -349,7 +349,16 @@
                              IsReadOnlyCaretVisible="True"
                              AcceptsReturn="True"
                              HorizontalScrollBarVisibility="Auto"
-                             VerticalScrollBarVisibility="Auto" />
+                             VerticalScrollBarVisibility="Auto">
+                        <TextBox.InputBindings>
+                            <KeyBinding Key="Up"
+                                        Modifiers="Control"
+                                        Command="{Binding DataContext.MoveSelectionUpCommand, RelativeSource={RelativeSource AncestorType=Window}}" />
+                            <KeyBinding Key="Down"
+                                        Modifiers="Control"
+                                        Command="{Binding DataContext.MoveSelectionDownCommand, RelativeSource={RelativeSource AncestorType=Window}}" />
+                        </TextBox.InputBindings>
+                    </TextBox>
                     <TextBox Grid.Row="2"
                              Grid.Column="1"
                              x:Name="SelectedTranslatedTextBox"
@@ -361,7 +370,16 @@
                              local:TextBoxNewlineMarker.IsEnabled="True"
                              AcceptsReturn="True"
                              HorizontalScrollBarVisibility="Auto"
-                             VerticalScrollBarVisibility="Auto" />
+                             VerticalScrollBarVisibility="Auto">
+                        <TextBox.InputBindings>
+                            <KeyBinding Key="Up"
+                                        Modifiers="Control"
+                                        Command="{Binding DataContext.MoveSelectionUpCommand, RelativeSource={RelativeSource AncestorType=Window}}" />
+                            <KeyBinding Key="Down"
+                                        Modifiers="Control"
+                                        Command="{Binding DataContext.MoveSelectionDownCommand, RelativeSource={RelativeSource AncestorType=Window}}" />
+                        </TextBox.InputBindings>
+                    </TextBox>
                 </Grid>
 
                 <StackPanel Grid.Row="6"


### PR DESCRIPTION
## 📌 概要

<!-- このPRの目的・背景を簡潔に書いてください -->
TranslationCreation DialogのSelectedOriginalTextBox, SelectedTranslatedTextBox内にフォーカスがあるときにショートカットが抜けていた

## 🛠 変更内容

<!-- このPRで加えた変更をリストアップしてください -->
- CTRL Up/Dnで選択項目を変更できるようにした

## 留意点

<!-- このPRを使用するうえで注意すべきことをリストアップしてください。 -->
<!-- 必要がなければ N/A としてください -->
N/A

Closes #107 