### PR TITLE
fix(wpf): WindowChromeBehaviorを共通化してCreatePullRequestViewの依存を解消

### DIFF
--- a/src/DcsTranslationTool.Presentation.Wpf/Features/Common/WindowChromeBehavior.cs
+++ b/src/DcsTranslationTool.Presentation.Wpf/Features/Common/WindowChromeBehavior.cs
@@ -4,12 +4,12 @@ using System.Windows.Input;
 
 using Microsoft.Xaml.Behaviors;
 
-namespace DcsTranslationTool.Presentation.Wpf.Features.TranslationCreation;
+namespace DcsTranslationTool.Presentation.Wpf.Features.Common;
 
 /// <summary>
-/// TranslationCreationView のウィンドウ操作を仲介する。
+/// 共通ウィンドウタイトルバーの操作を仲介する。
 /// </summary>
-public sealed class TranslationCreationWindowChromeBehavior : Behavior<Window> {
+public sealed class WindowChromeBehavior : Behavior<Window> {
     /// <summary>
     /// タイトルバー要素を取得または設定する。
     /// </summary>
@@ -49,7 +49,7 @@ public sealed class TranslationCreationWindowChromeBehavior : Behavior<Window> {
         DependencyProperty.Register(
             nameof( TitleBar ),
             typeof( FrameworkElement ),
-            typeof( TranslationCreationWindowChromeBehavior ),
+            typeof( WindowChromeBehavior ),
             new PropertyMetadata( null, OnTitleBarChanged ) );
 
     /// <summary>
@@ -59,7 +59,7 @@ public sealed class TranslationCreationWindowChromeBehavior : Behavior<Window> {
         DependencyProperty.Register(
             nameof( MinimizeButton ),
             typeof( ButtonBase ),
-            typeof( TranslationCreationWindowChromeBehavior ),
+            typeof( WindowChromeBehavior ),
             new PropertyMetadata( null, OnMinimizeButtonChanged ) );
 
     /// <summary>
@@ -69,7 +69,7 @@ public sealed class TranslationCreationWindowChromeBehavior : Behavior<Window> {
         DependencyProperty.Register(
             nameof( ToggleMaximizeButton ),
             typeof( ButtonBase ),
-            typeof( TranslationCreationWindowChromeBehavior ),
+            typeof( WindowChromeBehavior ),
             new PropertyMetadata( null, OnToggleMaximizeButtonChanged ) );
 
     /// <summary>
@@ -79,7 +79,7 @@ public sealed class TranslationCreationWindowChromeBehavior : Behavior<Window> {
         DependencyProperty.Register(
             nameof( CloseButton ),
             typeof( ButtonBase ),
-            typeof( TranslationCreationWindowChromeBehavior ),
+            typeof( WindowChromeBehavior ),
             new PropertyMetadata( null, OnCloseButtonChanged ) );
 
     /// <summary>
@@ -264,7 +264,7 @@ public sealed class TranslationCreationWindowChromeBehavior : Behavior<Window> {
     /// <param name="d">対象オブジェクト。</param>
     /// <param name="e">変更内容。</param>
     private static void OnTitleBarChanged( DependencyObject d, DependencyPropertyChangedEventArgs e ) {
-        var behavior = (TranslationCreationWindowChromeBehavior)d;
+        var behavior = (WindowChromeBehavior)d;
         behavior.DetachTitleBar( e.OldValue as FrameworkElement );
         behavior.AttachTitleBar( e.NewValue as FrameworkElement );
     }
@@ -275,7 +275,7 @@ public sealed class TranslationCreationWindowChromeBehavior : Behavior<Window> {
     /// <param name="d">対象オブジェクト。</param>
     /// <param name="e">変更内容。</param>
     private static void OnMinimizeButtonChanged( DependencyObject d, DependencyPropertyChangedEventArgs e ) {
-        var behavior = (TranslationCreationWindowChromeBehavior)d;
+        var behavior = (WindowChromeBehavior)d;
         behavior.DetachMinimizeButton( e.OldValue as ButtonBase );
         behavior.AttachMinimizeButton( e.NewValue as ButtonBase );
     }
@@ -286,7 +286,7 @@ public sealed class TranslationCreationWindowChromeBehavior : Behavior<Window> {
     /// <param name="d">対象オブジェクト。</param>
     /// <param name="e">変更内容。</param>
     private static void OnToggleMaximizeButtonChanged( DependencyObject d, DependencyPropertyChangedEventArgs e ) {
-        var behavior = (TranslationCreationWindowChromeBehavior)d;
+        var behavior = (WindowChromeBehavior)d;
         behavior.DetachToggleMaximizeButton( e.OldValue as ButtonBase );
         behavior.AttachToggleMaximizeButton( e.NewValue as ButtonBase );
     }
@@ -297,7 +297,7 @@ public sealed class TranslationCreationWindowChromeBehavior : Behavior<Window> {
     /// <param name="d">対象オブジェクト。</param>
     /// <param name="e">変更内容。</param>
     private static void OnCloseButtonChanged( DependencyObject d, DependencyPropertyChangedEventArgs e ) {
-        var behavior = (TranslationCreationWindowChromeBehavior)d;
+        var behavior = (WindowChromeBehavior)d;
         behavior.DetachCloseButton( e.OldValue as ButtonBase );
         behavior.AttachCloseButton( e.NewValue as ButtonBase );
     }

--- a/src/DcsTranslationTool.Presentation.Wpf/Features/CreatePullRequest/CreatePullRequestView.xaml
+++ b/src/DcsTranslationTool.Presentation.Wpf/Features/CreatePullRequest/CreatePullRequestView.xaml
@@ -14,11 +14,75 @@
         Background="{StaticResource MaterialDesign.Brush.Background}"
         FontFamily="/Assets/Fonts/#Zen kaku Gothic New"
         FontWeight="Medium"
-        Width="800" d:Height="800">
+        Title="{Binding PRTitle}"
+        Width="800"
+        d:Height="800">
+
+    <i:Interaction.Behaviors>
+        <common:WindowChromeBehavior TitleBar="{x:Reference TitleBar}"
+                                     MinimizeButton="{x:Reference MinimizeWindowButton}"
+                                     ToggleMaximizeButton="{x:Reference ToggleMaximizeWindowButton}"
+                                     CloseButton="{x:Reference CloseWindowButton}" />
+    </i:Interaction.Behaviors>
+
+    <WindowChrome.WindowChrome>
+        <WindowChrome
+            CaptionHeight="30"
+            ResizeBorderThickness="8"
+            GlassFrameThickness="0"
+            CornerRadius="0"
+            UseAeroCaptionButtons="False" />
+    </WindowChrome.WindowChrome>
 
     <md:DialogHost Identifier="{x:Static local:CreatePullRequestDialogHostIdentifiers.Validation}">
-        <ScrollViewer>
-            <StackPanel Margin="{StaticResource MediumMargin}">
+        <Grid x:Name="RootLayout">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
+
+            <Grid Grid.Row="0"
+                  x:Name="TitleBar"
+                  Height="30"
+                  Background="{StaticResource MaterialDesign.Brush.Primary}">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+
+                <TextBlock Grid.Column="0"
+                           Margin="{StaticResource MediumXMargin}"
+                           VerticalAlignment="Center"
+                           Text="{Binding PRTitle}"
+                           Style="{StaticResource MaterialDesignTitleMediumTextBlock}"
+                           Foreground="{StaticResource MaterialDesign.Brush.Background}" />
+
+                <StackPanel Grid.Column="1"
+                            Orientation="Horizontal"
+                            WindowChrome.IsHitTestVisibleInChrome="True">
+                    <Button x:Name="MinimizeWindowButton"
+                            Content="{md:PackIcon Kind=WindowMinimize}"
+                            Style="{StaticResource NavigationButtonStyle}" />
+                    <Button x:Name="ToggleMaximizeWindowButton">
+                        <Button.Style>
+                            <Style TargetType="Button" BasedOn="{StaticResource NavigationButtonStyle}">
+                                <Setter Property="Content" Value="{md:PackIcon Kind=WindowMaximize}" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding RelativeSource={RelativeSource AncestorType=Window}, Path=WindowState}" Value="Maximized">
+                                        <Setter Property="Content" Value="{md:PackIcon Kind=WindowRestore}" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Button.Style>
+                    </Button>
+                    <Button x:Name="CloseWindowButton"
+                            Content="{md:PackIcon Kind=Close}"
+                            Style="{StaticResource CloseButtonStyle}" />
+                </StackPanel>
+            </Grid>
+
+            <ScrollViewer Grid.Row="1">
+                <StackPanel Margin="{StaticResource MediumMargin}">
 
                 <!--アップロードするファイル一覧-->
                 <Expander Header="{x:Static resx:Strings_CreatePullRequest.UploadFileListHeader}"
@@ -170,7 +234,8 @@
                                      IsIndeterminate="True"
                                      IsEnabled="{Binding CanCreatePullRequest}"
                                      cal:Message.Attach="[Event Click] = [Action CreatePullRequest]" />
-            </StackPanel>
-        </ScrollViewer>
+                </StackPanel>
+            </ScrollViewer>
+        </Grid>
     </md:DialogHost>
 </Window>

--- a/src/DcsTranslationTool.Presentation.Wpf/Features/TranslationCreation/TranslationCreationView.xaml
+++ b/src/DcsTranslationTool.Presentation.Wpf/Features/TranslationCreation/TranslationCreationView.xaml
@@ -2,6 +2,7 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:common="clr-namespace:DcsTranslationTool.Presentation.Wpf.Features.Common"
         xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:DcsTranslationTool.Presentation.Wpf.Features.TranslationCreation"
@@ -66,10 +67,10 @@
     </Window.Resources>
     
     <i:Interaction.Behaviors>
-        <local:TranslationCreationWindowChromeBehavior TitleBar="{x:Reference TitleBar}"
-                                                       MinimizeButton="{x:Reference MinimizeWindowButton}"
-                                                       ToggleMaximizeButton="{x:Reference ToggleMaximizeWindowButton}"
-                                                       CloseButton="{x:Reference CloseWindowButton}" />
+        <common:WindowChromeBehavior TitleBar="{x:Reference TitleBar}"
+                                     MinimizeButton="{x:Reference MinimizeWindowButton}"
+                                     ToggleMaximizeButton="{x:Reference ToggleMaximizeWindowButton}"
+                                     CloseButton="{x:Reference CloseWindowButton}" />
         <local:TranslationCreationLayoutBehavior DictionaryDataGridRowDefinition="{x:Reference DictionaryDataGridRowDefinition}"
                                                  DictionaryDetailsRowDefinition="{x:Reference DictionaryDetailsRowDefinition}"
                                                  DictionaryPaneGridSplitter="{x:Reference DictionaryPaneGridSplitter}" />

--- a/tests/DcsTranslationTool.Presentation.Wpf.UnitTests/Features/TranslationCreation/TranslationCreationViewBehaviorsTests.cs
+++ b/tests/DcsTranslationTool.Presentation.Wpf.UnitTests/Features/TranslationCreation/TranslationCreationViewBehaviorsTests.cs
@@ -5,6 +5,7 @@ using System.Windows.Controls.Primitives;
 using System.Windows.Data;
 
 using DcsTranslationTool.Application.Models;
+using DcsTranslationTool.Presentation.Wpf.Features.Common;
 using DcsTranslationTool.Presentation.Wpf.Features.TranslationCreation;
 
 using Microsoft.Xaml.Behaviors;
@@ -87,7 +88,7 @@ public sealed class TranslationCreationViewBehaviorsTests {
         var toggleMaximizeButton = new Button();
         var closeButton = new Button();
         var window = new TestWindow();
-        var behavior = new TranslationCreationWindowChromeBehavior
+        var behavior = new WindowChromeBehavior
         {
             TitleBar = titleBar,
             MinimizeButton = minimizeButton,


### PR DESCRIPTION
## 📌 概要

<!-- このPRの目的・背景を簡潔に書いてください -->
CreatePullRequestダイアログにタイトルバーを追加

## 🛠 変更内容

<!-- このPRで加えた変更をリストアップしてください -->
- TranslationCreationViewのBehaviorを共通コンポーネント化
- CreatePullRequestViewにBehaviorを追加

## 留意点

<!-- このPRを使用するうえで注意すべきことをリストアップしてください。 -->
<!-- 必要がなければ N/A としてください -->
N/A

Closes #109 