### PR TITLE
feat(download): Download 適用時に差分ファイルごとの適用元を選択できるようにする

### DIFF
--- a/src/DcsTranslationTool.Presentation.Wpf/Features/Download/DownloadViewModel.cs
+++ b/src/DcsTranslationTool.Presentation.Wpf/Features/Download/DownloadViewModel.cs
@@ -94,7 +94,7 @@ public class DownloadViewModel(
     /// <summary>
     /// ダウンロード可能か
     /// </summary>
-    public bool CanDownload => !IsDownloading && HasCheckedEntries();
+    public bool CanDownload => !IsDownloading && GetDownloadableCheckedEntries().Count > 0;
 
     /// <summary>
     /// 適用可能か
@@ -255,6 +255,17 @@ public class DownloadViewModel(
         Tabs.Count > 0 && SelectedTabIndex >= 0 && SelectedTabIndex < Tabs.Count
             ? Tabs[SelectedTabIndex]
             : null;
+
+    /// <summary>
+    /// 選択中タブのうちダウンロード可能なチェック済みファイル一覧を取得する。
+    /// </summary>
+    /// <returns>ダウンロード可能なチェック済みファイル一覧。</returns>
+    private IReadOnlyList<IFileEntryViewModel> GetDownloadableCheckedEntries() =>
+        GetSelectedTab()?.GetCheckedViewModels()
+            .Where( entry => !entry.IsDirectory )
+            .Where( entry => entry.ChangeType is FileChangeType.Modified or FileChangeType.RepoOnly )
+            .ToArray()
+        ?? [];
 
     /// <summary>
     /// Modified 適用時にサーバー同期対象を解決する。

--- a/src/DcsTranslationTool.Presentation.Wpf/Features/Download/DownloadViewModel.cs
+++ b/src/DcsTranslationTool.Presentation.Wpf/Features/Download/DownloadViewModel.cs
@@ -1,8 +1,13 @@
 using DcsTranslationTool.Application.Interfaces;
+using DcsTranslationTool.Domain.Models;
 using DcsTranslationTool.Presentation.Wpf.Features.Common;
 using DcsTranslationTool.Presentation.Wpf.Services.Abstractions;
+using DcsTranslationTool.Presentation.Wpf.UI.Dialogs.Parameters;
+using DcsTranslationTool.Presentation.Wpf.UI.Dialogs.Results;
 using DcsTranslationTool.Presentation.Wpf.UI.Enums;
+using DcsTranslationTool.Presentation.Wpf.UI.Interfaces;
 using DcsTranslationTool.Presentation.Wpf.ViewModels;
+using DcsTranslationTool.Resources;
 
 namespace DcsTranslationTool.Presentation.Wpf.Features.Download;
 
@@ -12,6 +17,7 @@ namespace DcsTranslationTool.Presentation.Wpf.Features.Download;
 public class DownloadViewModel(
     IApiService apiService,
     IAppSettingsService appSettingsService,
+    IDialogService dialogService,
     IDownloadWorkflowService downloadWorkflowService,
     IDispatcherService dispatcherService,
     IFileEntryService fileEntryService,
@@ -142,8 +148,37 @@ public class DownloadViewModel(
         }
 
         await ExecuteWithEntriesChangedSuppressedAsync( isDownload: false, async () => {
+            var selectedTab = GetSelectedTab();
+            var checkedEntries = selectedTab?.GetCheckedViewModels()
+                .Where( entry => !entry.IsDirectory )
+                .ToList()
+                ?? [];
+            var modifiedEntries = checkedEntries
+                .Where( entry => entry.ChangeType == FileChangeType.Modified )
+                .ToList();
+
+            if(modifiedEntries.Count > 0) {
+                var repositoryTargets = await ResolveRepositorySyncTargetsAsync( modifiedEntries );
+                if(repositoryTargets is null) {
+                    Logger.Warn( "差分ファイル適用確認で中止が選択されたため処理を終了する。" );
+                    return;
+                }
+
+                if(repositoryTargets.Count > 0) {
+                    var synced = await downloadWorkflowService.SyncModifiedFilesWithRepositoryAsync(
+                        repositoryTargets,
+                        appSettingsService.Settings.TranslateFileDir,
+                        UiAdapter.ShowSnackbarAsync
+                    );
+                    if(!synced) {
+                        Logger.Warn( "サーバー版での差分同期に失敗したため適用処理を中断する。" );
+                        return;
+                    }
+                }
+            }
+
             var request = new ApplyExecutionRequest(
-                GetSelectedTab(),
+                selectedTab,
                 appSettingsService.Settings.DcsWorldInstallDir,
                 appSettingsService.Settings.SourceUserMissionDir,
                 appSettingsService.Settings.UseExternalAircraftInjectionDir,
@@ -220,6 +255,70 @@ public class DownloadViewModel(
         Tabs.Count > 0 && SelectedTabIndex >= 0 && SelectedTabIndex < Tabs.Count
             ? Tabs[SelectedTabIndex]
             : null;
+
+    /// <summary>
+    /// Modified 適用時にサーバー同期対象を解決する。
+    /// </summary>
+    /// <param name="modifiedEntries">差分エントリ一覧。</param>
+    /// <returns>サーバー同期対象。中止時は <see langword="null"/>。</returns>
+    private async Task<IReadOnlyList<IFileEntryViewModel>?> ResolveRepositorySyncTargetsAsync( IReadOnlyList<IFileEntryViewModel> modifiedEntries ) {
+        var modeResult = await dialogService.DownloadModifiedApplyModeDialogShowAsync(
+            new DownloadModifiedApplyModeDialogParameters
+            {
+                Title = Strings_Download.ModifiedApplyModeDialogTitle,
+                Message = string.Format( Strings_Download.ModifiedApplyModeDialogMessage, modifiedEntries.Count ),
+                ApplyAllRepositoryButtonText = Strings_Download.ModifiedApplyModeDialogApplyAllRepositoryButtonText,
+                ApplyAllLocalButtonText = Strings_Download.ModifiedApplyModeDialogApplyAllLocalButtonText,
+                SelectIndividuallyButtonText = Strings_Download.ModifiedApplyModeDialogSelectIndividuallyButtonText,
+                CancelButtonText = Strings_Download.ModifiedApplyModeDialogCancelButtonText,
+            } );
+
+        switch(modeResult) {
+            case DownloadModifiedApplyModeDialogResult.ApplyAllRepository:
+                return modifiedEntries.ToList();
+            case DownloadModifiedApplyModeDialogResult.ApplyAllLocal:
+                return [];
+            case DownloadModifiedApplyModeDialogResult.SelectIndividually:
+                return await ResolveRepositoryTargetsFromSelectionDialogAsync( modifiedEntries );
+            case DownloadModifiedApplyModeDialogResult.Cancel:
+            default:
+                return null;
+        }
+    }
+
+    /// <summary>
+    /// 個別選択ダイアログからサーバー同期対象を解決する。
+    /// </summary>
+    /// <param name="modifiedEntries">差分エントリ一覧。</param>
+    /// <returns>サーバー同期対象。中止時は <see langword="null"/>。</returns>
+    private async Task<IReadOnlyList<IFileEntryViewModel>?> ResolveRepositoryTargetsFromSelectionDialogAsync( IReadOnlyList<IFileEntryViewModel> modifiedEntries ) {
+        var items = modifiedEntries
+            .Select( entry => new DownloadModifiedApplySelectionItem( entry.Path ) )
+            .ToArray();
+
+        var selectionResult = await dialogService.DownloadModifiedApplySelectionDialogShowAsync(
+            new DownloadModifiedApplySelectionDialogParameters
+            {
+                Title = Strings_Download.ModifiedApplySelectionDialogTitle,
+                Message = string.Format( Strings_Download.ModifiedApplySelectionDialogMessage, modifiedEntries.Count ),
+                PathHeader = Strings_Download.ModifiedApplySelectionDialogPathHeader,
+                RepositoryHeader = Strings_Download.ModifiedApplySelectionDialogRepositoryHeader,
+                LocalHeader = Strings_Download.ModifiedApplySelectionDialogLocalHeader,
+                ConfirmButtonText = Strings_Download.ModifiedApplySelectionDialogConfirmButtonText,
+                CancelButtonText = Strings_Download.ModifiedApplySelectionDialogCancelButtonText,
+                Items = items,
+            } );
+
+        if(!selectionResult.IsConfirmed) {
+            return null;
+        }
+
+        return modifiedEntries
+            .Where( entry =>
+                selectionResult.SelectedSources.TryGetValue( entry.Path, out var source ) &&
+                source == DownloadModifiedApplySource.Repository )
+            .ToList();
+    }
 
     /// <summary>
     /// ワークフローイベントを UI へ反映する。

--- a/src/DcsTranslationTool.Presentation.Wpf/Services/Abstractions/IDialogService.cs
+++ b/src/DcsTranslationTool.Presentation.Wpf/Services/Abstractions/IDialogService.cs
@@ -15,6 +15,20 @@ public interface IDialogService {
     Task<ConfirmationDialogResult> ConfirmationDialogShowAsync( ConfirmationDialogParameters parameters );
 
     /// <summary>
+    /// Download Page の差分適用モード選択ダイアログを表示して結果を取得する。
+    /// </summary>
+    /// <param name="parameters">表示に利用する引数。</param>
+    /// <returns>選択結果。</returns>
+    Task<DownloadModifiedApplyModeDialogResult> DownloadModifiedApplyModeDialogShowAsync( DownloadModifiedApplyModeDialogParameters parameters );
+
+    /// <summary>
+    /// Download Page の差分個別選択ダイアログを表示して結果を取得する。
+    /// </summary>
+    /// <param name="parameters">表示に利用する引数。</param>
+    /// <returns>選択結果。</returns>
+    Task<DownloadModifiedApplySelectionDialogResult> DownloadModifiedApplySelectionDialogShowAsync( DownloadModifiedApplySelectionDialogParameters parameters );
+
+    /// <summary>
     /// ダイアログを表示して結果を取得する。
     /// </summary>
     /// <param name="parameters">表示に利用する引数。</param>

--- a/src/DcsTranslationTool.Presentation.Wpf/Services/Abstractions/IDownloadWorkflowService.cs
+++ b/src/DcsTranslationTool.Presentation.Wpf/Services/Abstractions/IDownloadWorkflowService.cs
@@ -36,6 +36,21 @@ public interface IDownloadWorkflowService {
     );
 
     /// <summary>
+    /// Modified の翻訳ファイルをサーバー版で翻訳ディレクトリへ同期する。
+    /// </summary>
+    /// <param name="targetEntries">同期対象エントリ。</param>
+    /// <param name="translateRootPath">翻訳ファイルルート。</param>
+    /// <param name="showSnackbarAsync">通知コールバック。</param>
+    /// <param name="cancellationToken">キャンセルトークン。</param>
+    /// <returns>同期完了時は <see langword="true"/>。</returns>
+    Task<bool> SyncModifiedFilesWithRepositoryAsync(
+        IReadOnlyList<IFileEntryViewModel> targetEntries,
+        string translateRootPath,
+        Func<string, Task> showSnackbarAsync,
+        CancellationToken cancellationToken = default
+    );
+
+    /// <summary>
     /// ダウンロードURL一覧からファイルを保存する。
     /// </summary>
     /// <param name="items">ダウンロード対象一覧。</param>

--- a/src/DcsTranslationTool.Presentation.Wpf/Services/DialogService.cs
+++ b/src/DcsTranslationTool.Presentation.Wpf/Services/DialogService.cs
@@ -58,6 +58,61 @@ public sealed class DialogService(
     }
 
     /// <inheritdoc/>
+    public async Task<DownloadModifiedApplyModeDialogResult> DownloadModifiedApplyModeDialogShowAsync( DownloadModifiedApplyModeDialogParameters parameters ) {
+        ArgumentNullException.ThrowIfNull( parameters );
+        logger.Info( $"差分適用モード選択ダイアログを表示する。Title={parameters.Title}, Identifier={parameters.DialogIdentifier}" );
+        var dialog = new DownloadModifiedApplyModeDialog
+        {
+            DataContext = parameters
+        };
+
+        object? result;
+        try {
+            result = await DialogHost.Show( dialog, parameters.DialogIdentifier );
+        }
+        catch(InvalidOperationException ex) {
+            logger.Error( $"差分適用モード選択ダイアログ表示に失敗した。Identifier={parameters.DialogIdentifier}", ex );
+            throw;
+        }
+
+        var dialogResult = result switch
+        {
+            DownloadModifiedApplyModeDialogResult modeDialogResult => modeDialogResult,
+            string value when Enum.TryParse<DownloadModifiedApplyModeDialogResult>( value, true, out var parsed ) => parsed,
+            _ => DownloadModifiedApplyModeDialogResult.Cancel
+        };
+        logger.Info( $"差分適用モード選択ダイアログが閉じられた。Result={dialogResult}" );
+        return dialogResult;
+    }
+
+    /// <inheritdoc/>
+    public async Task<DownloadModifiedApplySelectionDialogResult> DownloadModifiedApplySelectionDialogShowAsync( DownloadModifiedApplySelectionDialogParameters parameters ) {
+        ArgumentNullException.ThrowIfNull( parameters );
+        logger.Info( $"差分個別選択ダイアログを表示する。Title={parameters.Title}, Count={parameters.Items.Count}, Identifier={parameters.DialogIdentifier}" );
+        var dialog = new DownloadModifiedApplySelectionDialog
+        {
+            DataContext = parameters
+        };
+
+        object? result;
+        try {
+            result = await DialogHost.Show( dialog, parameters.DialogIdentifier );
+        }
+        catch(InvalidOperationException ex) {
+            logger.Error( $"差分個別選択ダイアログ表示に失敗した。Identifier={parameters.DialogIdentifier}", ex );
+            throw;
+        }
+
+        var dialogResult = result switch
+        {
+            DownloadModifiedApplySelectionDialogResult selectionDialogResult => selectionDialogResult,
+            _ => new DownloadModifiedApplySelectionDialogResult( false, new Dictionary<string, DownloadModifiedApplySource>( StringComparer.Ordinal ) )
+        };
+        logger.Info( $"差分個別選択ダイアログが閉じられた。IsConfirmed={dialogResult.IsConfirmed}, Count={dialogResult.SelectedSources.Count}" );
+        return dialogResult;
+    }
+
+    /// <inheritdoc/>
     public async Task<bool> ContinueCancelDialogShowAsync( ConfirmationDialogParameters parameters ) {
         var result = await ConfirmationDialogShowAsync( parameters );
         return result == ConfirmationDialogResult.Confirm;

--- a/src/DcsTranslationTool.Presentation.Wpf/Services/DownloadWorkflowService.cs
+++ b/src/DcsTranslationTool.Presentation.Wpf/Services/DownloadWorkflowService.cs
@@ -41,7 +41,10 @@ public sealed class DownloadWorkflowService(
         }
 
         var checkedEntries = request.SelectedTab.GetCheckedEntries();
-        var targetEntries = checkedEntries.Where( entry => !entry.IsDirectory ).ToList();
+        var targetEntries = checkedEntries
+            .Where( entry => !entry.IsDirectory )
+            .Where( static entry => entry.RepoSha is not null )
+            .ToList();
         if(targetEntries.Count == 0) {
             logger.Warn( "ダウンロード対象のファイルが存在しない。" );
             return FailureDownloadResult( "ダウンロード対象が有りません" );

--- a/src/DcsTranslationTool.Presentation.Wpf/Services/DownloadWorkflowService.cs
+++ b/src/DcsTranslationTool.Presentation.Wpf/Services/DownloadWorkflowService.cs
@@ -171,6 +171,69 @@ public sealed class DownloadWorkflowService(
     }
 
     /// <inheritdoc/>
+    public async Task<bool> SyncModifiedFilesWithRepositoryAsync(
+        IReadOnlyList<IFileEntryViewModel> targetEntries,
+        string translateRootPath,
+        Func<string, Task> showSnackbarAsync,
+        CancellationToken cancellationToken = default
+    ) {
+        var modifiedEntries = targetEntries
+            .Where( entry => entry.ChangeType == FileChangeType.Modified )
+            .ToList();
+        if(modifiedEntries.Count == 0) {
+            return true;
+        }
+
+        if(string.IsNullOrWhiteSpace( translateRootPath )) {
+            logger.Warn( "翻訳ディレクトリが未設定のため Modified 同期を中断する。" );
+            await showSnackbarAsync( "翻訳ディレクトリを設定してください" );
+            return false;
+        }
+
+        var translateFullPath = Path.GetFullPath( translateRootPath );
+        Directory.CreateDirectory( translateFullPath );
+        var translateRootWithSeparator = translateFullPath.EndsWith( Path.DirectorySeparatorChar )
+            ? translateFullPath
+            : translateFullPath + Path.DirectorySeparatorChar;
+
+        var paths = modifiedEntries.Select( entry => entry.Path ).ToList();
+        var pathResult = await apiService.DownloadFilePathsAsync(
+            new ApiDownloadFilePathsRequest( paths, null ),
+            cancellationToken
+        );
+        if(pathResult.IsFailed) {
+            var reason = pathResult.Errors.Count > 0 ? pathResult.Errors[0].Message : null;
+            var message = ResultNotificationPolicy.GetDownloadPathFailureMessage( pathResult.GetFirstErrorKind() );
+            logger.Error( $"Modified 同期のダウンロードURL取得に失敗した。Reason={reason}" );
+            await showSnackbarAsync( message );
+            return false;
+        }
+
+        var downloadItems = pathResult.Value.Items.ToArray();
+        logger.Info( $"Modified 同期のダウンロードURLを取得した。Count={downloadItems.Length}" );
+        if(downloadItems.Length > 0) {
+            await this.DownloadFilesAsync(
+                downloadItems,
+                translateFullPath,
+                _ => Task.CompletedTask,
+                cancellationToken
+            );
+        }
+
+        var pathSafetyGuard = new PathSafetyGuard();
+        foreach(var modifiedEntry in modifiedEntries) {
+            if(!pathSafetyGuard.TryResolvePathWithinRoot( translateFullPath, translateRootWithSeparator, modifiedEntry.Path, out var filePath ) ||
+                !File.Exists( filePath )) {
+                logger.Warn( $"Modified 同期後も翻訳ファイルが存在しない。Path={modifiedEntry.Path}, Resolved={filePath}" );
+                await showSnackbarAsync( $"取得失敗: {modifiedEntry.Path}" );
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <inheritdoc/>
     public async Task DownloadFilesAsync(
         IReadOnlyList<ApiDownloadFilePathsItem> items,
         string saveRootPath,

--- a/src/DcsTranslationTool.Presentation.Wpf/UI/Dialogs/Parameters/DownloadModifiedApplyModeDialogParameters.cs
+++ b/src/DcsTranslationTool.Presentation.Wpf/UI/Dialogs/Parameters/DownloadModifiedApplyModeDialogParameters.cs
@@ -1,0 +1,41 @@
+namespace DcsTranslationTool.Presentation.Wpf.UI.Dialogs.Parameters;
+
+/// <summary>
+/// Download Page の差分適用モード選択ダイアログ表示内容を表す。
+/// </summary>
+public sealed record DownloadModifiedApplyModeDialogParameters {
+    /// <summary>
+    /// タイトル文字列を取得する。
+    /// </summary>
+    public string Title { get; init; } = string.Empty;
+
+    /// <summary>
+    /// メッセージ本文を取得する。
+    /// </summary>
+    public string Message { get; init; } = string.Empty;
+
+    /// <summary>
+    /// 全てサーバー版適用ボタン文言を取得する。
+    /// </summary>
+    public string ApplyAllRepositoryButtonText { get; init; } = string.Empty;
+
+    /// <summary>
+    /// 全てローカル版適用ボタン文言を取得する。
+    /// </summary>
+    public string ApplyAllLocalButtonText { get; init; } = string.Empty;
+
+    /// <summary>
+    /// 個別選択ボタン文言を取得する。
+    /// </summary>
+    public string SelectIndividuallyButtonText { get; init; } = string.Empty;
+
+    /// <summary>
+    /// 中止ボタン文言を取得する。
+    /// </summary>
+    public string CancelButtonText { get; init; } = string.Empty;
+
+    /// <summary>
+    /// 表示対象のダイアログホスト識別子を取得する。
+    /// </summary>
+    public string DialogIdentifier { get; init; } = "RootDialogHost";
+}

--- a/src/DcsTranslationTool.Presentation.Wpf/UI/Dialogs/Parameters/DownloadModifiedApplySelectionDialogParameters.cs
+++ b/src/DcsTranslationTool.Presentation.Wpf/UI/Dialogs/Parameters/DownloadModifiedApplySelectionDialogParameters.cs
@@ -1,0 +1,62 @@
+using DcsTranslationTool.Presentation.Wpf.UI.Dialogs.Results;
+
+namespace DcsTranslationTool.Presentation.Wpf.UI.Dialogs.Parameters;
+
+/// <summary>
+/// Download Page の差分個別選択ダイアログ表示内容を表す。
+/// </summary>
+public sealed record DownloadModifiedApplySelectionDialogParameters {
+    /// <summary>
+    /// タイトル文字列を取得する。
+    /// </summary>
+    public string Title { get; init; } = string.Empty;
+
+    /// <summary>
+    /// メッセージ本文を取得する。
+    /// </summary>
+    public string Message { get; init; } = string.Empty;
+
+    /// <summary>
+    /// 一覧ヘッダーのファイルパス文言を取得する。
+    /// </summary>
+    public string PathHeader { get; init; } = string.Empty;
+
+    /// <summary>
+    /// 一覧ヘッダーのサーバー版文言を取得する。
+    /// </summary>
+    public string RepositoryHeader { get; init; } = string.Empty;
+
+    /// <summary>
+    /// 一覧ヘッダーのローカル版文言を取得する。
+    /// </summary>
+    public string LocalHeader { get; init; } = string.Empty;
+
+    /// <summary>
+    /// 確定ボタン文言を取得する。
+    /// </summary>
+    public string ConfirmButtonText { get; init; } = string.Empty;
+
+    /// <summary>
+    /// 中止ボタン文言を取得する。
+    /// </summary>
+    public string CancelButtonText { get; init; } = string.Empty;
+
+    /// <summary>
+    /// 選択項目一覧を取得する。
+    /// </summary>
+    public IReadOnlyList<DownloadModifiedApplySelectionItem> Items { get; init; } = [];
+
+    /// <summary>
+    /// 表示対象のダイアログホスト識別子を取得する。
+    /// </summary>
+    public string DialogIdentifier { get; init; } = "RootDialogHost";
+
+    /// <summary>
+    /// 現在の選択状態から結果を構築する。
+    /// </summary>
+    /// <returns>構築した結果を返す。</returns>
+    public DownloadModifiedApplySelectionDialogResult CreateResult() =>
+        new(
+            true,
+            Items.ToDictionary( item => item.Path, item => item.ApplySource, StringComparer.Ordinal ) );
+}

--- a/src/DcsTranslationTool.Presentation.Wpf/UI/Dialogs/Parameters/DownloadModifiedApplySelectionItem.cs
+++ b/src/DcsTranslationTool.Presentation.Wpf/UI/Dialogs/Parameters/DownloadModifiedApplySelectionItem.cs
@@ -1,0 +1,62 @@
+using Caliburn.Micro;
+
+using DcsTranslationTool.Presentation.Wpf.UI.Dialogs.Results;
+
+namespace DcsTranslationTool.Presentation.Wpf.UI.Dialogs.Parameters;
+
+/// <summary>
+/// Download Page の差分個別選択項目を表す。
+/// </summary>
+/// <param name="path">対象ファイルパス。</param>
+public sealed class DownloadModifiedApplySelectionItem( string path ) : PropertyChangedBase {
+    private DownloadModifiedApplySource _applySource = DownloadModifiedApplySource.Local;
+
+    /// <summary>
+    /// 対象ファイルパスを取得する。
+    /// </summary>
+    public string Path { get; } = path;
+
+    /// <summary>
+    /// ラジオボタンのグループ名を取得する。
+    /// </summary>
+    public string GroupName { get; } = $"DownloadModifiedApplySelection_{Guid.NewGuid():N}";
+
+    /// <summary>
+    /// 適用元を取得または設定する。
+    /// </summary>
+    public DownloadModifiedApplySource ApplySource {
+        get => _applySource;
+        set {
+            if(!Set( ref _applySource, value )) {
+                return;
+            }
+
+            NotifyOfPropertyChange( nameof( IsRepositorySelected ) );
+            NotifyOfPropertyChange( nameof( IsLocalSelected ) );
+        }
+    }
+
+    /// <summary>
+    /// サーバー版が選択されているかどうかを取得または設定する。
+    /// </summary>
+    public bool IsRepositorySelected {
+        get => ApplySource == DownloadModifiedApplySource.Repository;
+        set {
+            if(value) {
+                ApplySource = DownloadModifiedApplySource.Repository;
+            }
+        }
+    }
+
+    /// <summary>
+    /// ローカル版が選択されているかどうかを取得または設定する。
+    /// </summary>
+    public bool IsLocalSelected {
+        get => ApplySource == DownloadModifiedApplySource.Local;
+        set {
+            if(value) {
+                ApplySource = DownloadModifiedApplySource.Local;
+            }
+        }
+    }
+}

--- a/src/DcsTranslationTool.Presentation.Wpf/UI/Dialogs/Results/DownloadModifiedApplyModeDialogResult.cs
+++ b/src/DcsTranslationTool.Presentation.Wpf/UI/Dialogs/Results/DownloadModifiedApplyModeDialogResult.cs
@@ -1,0 +1,26 @@
+namespace DcsTranslationTool.Presentation.Wpf.UI.Dialogs.Results;
+
+/// <summary>
+/// Download Page の差分適用モード選択結果を表す。
+/// </summary>
+public enum DownloadModifiedApplyModeDialogResult {
+    /// <summary>
+    /// 全てサーバー版を適用することを表す。
+    /// </summary>
+    ApplyAllRepository,
+
+    /// <summary>
+    /// 全てローカル版を適用することを表す。
+    /// </summary>
+    ApplyAllLocal,
+
+    /// <summary>
+    /// 個別に選択することを表す。
+    /// </summary>
+    SelectIndividually,
+
+    /// <summary>
+    /// 中止することを表す。
+    /// </summary>
+    Cancel,
+}

--- a/src/DcsTranslationTool.Presentation.Wpf/UI/Dialogs/Results/DownloadModifiedApplySelectionDialogResult.cs
+++ b/src/DcsTranslationTool.Presentation.Wpf/UI/Dialogs/Results/DownloadModifiedApplySelectionDialogResult.cs
@@ -1,0 +1,11 @@
+namespace DcsTranslationTool.Presentation.Wpf.UI.Dialogs.Results;
+
+/// <summary>
+/// Download Page の差分個別選択ダイアログ結果を表す。
+/// </summary>
+/// <param name="IsConfirmed">確定されたかどうか。</param>
+/// <param name="SelectedSources">ファイルパスごとの適用元。</param>
+public sealed record DownloadModifiedApplySelectionDialogResult(
+    bool IsConfirmed,
+    IReadOnlyDictionary<string, DownloadModifiedApplySource> SelectedSources
+);

--- a/src/DcsTranslationTool.Presentation.Wpf/UI/Dialogs/Results/DownloadModifiedApplySource.cs
+++ b/src/DcsTranslationTool.Presentation.Wpf/UI/Dialogs/Results/DownloadModifiedApplySource.cs
@@ -1,0 +1,16 @@
+namespace DcsTranslationTool.Presentation.Wpf.UI.Dialogs.Results;
+
+/// <summary>
+/// Download Page の差分ファイルに適用するソース種別を表す。
+/// </summary>
+public enum DownloadModifiedApplySource {
+    /// <summary>
+    /// サーバー版を適用することを表す。
+    /// </summary>
+    Repository,
+
+    /// <summary>
+    /// ローカル版を適用することを表す。
+    /// </summary>
+    Local,
+}

--- a/src/DcsTranslationTool.Presentation.Wpf/UI/Dialogs/Views/DownloadModifiedApplyModeDialog.xaml
+++ b/src/DcsTranslationTool.Presentation.Wpf/UI/Dialogs/Views/DownloadModifiedApplyModeDialog.xaml
@@ -1,0 +1,55 @@
+<UserControl x:Class="DcsTranslationTool.Presentation.Wpf.UI.Dialogs.Views.DownloadModifiedApplyModeDialog"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:md="http://materialdesigninxaml.net/winfx/xaml/themes"
+             xmlns:local="clr-namespace:DcsTranslationTool.Presentation.Wpf.UI.Dialogs.Results"
+             mc:Ignorable="d"
+             d:DesignHeight="280"
+             d:DesignWidth="440">
+    <Border Background="{DynamicResource MaterialDesign.Brush.Background}"
+            Padding="{StaticResource MediumMargin}"
+            BorderBrush="{DynamicResource MaterialDesign.Brush.OutlineVariant}"
+            BorderThickness="1">
+        <StackPanel>
+            <TextBlock Text="{Binding Title}"
+                       Style="{StaticResource MaterialDesignHeadlineSmallTextBlock}"
+                       Margin="{StaticResource XSmallBottomMargin}" />
+            <TextBlock Text="{Binding Message}"
+                       Style="{StaticResource MaterialDesignBodyMediumTextBlock}"
+                       TextWrapping="Wrap"
+                       Margin="{StaticResource SmallBottomMargin}" />
+
+            <StackPanel>
+                <Button x:Name="ApplyAllRepositoryButton"
+                        Command="{x:Static md:DialogHost.CloseDialogCommand}"
+                        CommandParameter="{x:Static local:DownloadModifiedApplyModeDialogResult.ApplyAllRepository}"
+                        Content="{Binding ApplyAllRepositoryButtonText}"
+                        Style="{StaticResource MaterialDesignRaisedButton}"
+                        HorizontalAlignment="Stretch"
+                        Margin="{StaticResource XSmallBottomMargin}" />
+                <Button x:Name="ApplyAllLocalButton"
+                        Command="{x:Static md:DialogHost.CloseDialogCommand}"
+                        CommandParameter="{x:Static local:DownloadModifiedApplyModeDialogResult.ApplyAllLocal}"
+                        Content="{Binding ApplyAllLocalButtonText}"
+                        Style="{StaticResource MaterialDesignRaisedButton}"
+                        HorizontalAlignment="Stretch"
+                        Margin="{StaticResource XSmallBottomMargin}" />
+                <Button x:Name="SelectIndividuallyButton"
+                        Command="{x:Static md:DialogHost.CloseDialogCommand}"
+                        CommandParameter="{x:Static local:DownloadModifiedApplyModeDialogResult.SelectIndividually}"
+                        Content="{Binding SelectIndividuallyButtonText}"
+                        Style="{StaticResource MaterialDesignRaisedButton}"
+                        HorizontalAlignment="Stretch"
+                        Margin="{StaticResource XSmallBottomMargin}" />
+                <Button x:Name="CancelButton"
+                        Command="{x:Static md:DialogHost.CloseDialogCommand}"
+                        CommandParameter="{x:Static local:DownloadModifiedApplyModeDialogResult.Cancel}"
+                        Content="{Binding CancelButtonText}"
+                        Style="{StaticResource MaterialDesignRaisedButton}"
+                        HorizontalAlignment="Stretch" />
+            </StackPanel>
+        </StackPanel>
+    </Border>
+</UserControl>

--- a/src/DcsTranslationTool.Presentation.Wpf/UI/Dialogs/Views/DownloadModifiedApplyModeDialog.xaml.cs
+++ b/src/DcsTranslationTool.Presentation.Wpf/UI/Dialogs/Views/DownloadModifiedApplyModeDialog.xaml.cs
@@ -1,0 +1,15 @@
+using System.Windows.Controls;
+
+namespace DcsTranslationTool.Presentation.Wpf.UI.Dialogs.Views;
+
+/// <summary>
+/// DownloadModifiedApplyModeDialog.xaml の相互作用ロジックを提供する。
+/// </summary>
+public partial class DownloadModifiedApplyModeDialog : UserControl {
+    /// <summary>
+    /// DownloadModifiedApplyModeDialog の新しいインスタンスを初期化する。
+    /// </summary>
+    public DownloadModifiedApplyModeDialog() {
+        InitializeComponent();
+    }
+}

--- a/src/DcsTranslationTool.Presentation.Wpf/UI/Dialogs/Views/DownloadModifiedApplySelectionDialog.xaml
+++ b/src/DcsTranslationTool.Presentation.Wpf/UI/Dialogs/Views/DownloadModifiedApplySelectionDialog.xaml
@@ -1,0 +1,115 @@
+<UserControl x:Class="DcsTranslationTool.Presentation.Wpf.UI.Dialogs.Views.DownloadModifiedApplySelectionDialog"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:md="http://materialdesigninxaml.net/winfx/xaml/themes"
+             mc:Ignorable="d"
+             d:DesignHeight="420"
+             d:DesignWidth="720">
+    <Border Background="{DynamicResource MaterialDesign.Brush.Background}"
+            Padding="{StaticResource MediumMargin}"
+            BorderBrush="{DynamicResource MaterialDesign.Brush.OutlineVariant}"
+            BorderThickness="1">
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+
+            <StackPanel Grid.Row="0">
+                <TextBlock Text="{Binding Title}"
+                           Style="{StaticResource MaterialDesignHeadlineSmallTextBlock}"
+                           Margin="{StaticResource XSmallBottomMargin}" />
+                <TextBlock Text="{Binding Message}"
+                           Style="{StaticResource MaterialDesignBodyMediumTextBlock}"
+                           TextWrapping="Wrap"
+                           Margin="{StaticResource SmallBottomMargin}" />
+            </StackPanel>
+
+            <Border Grid.Row="1"
+                    BorderBrush="{DynamicResource MaterialDesign.Brush.OutlineVariant}"
+                    BorderThickness="1"
+                    Margin="{StaticResource SmallBottomMargin}">
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="*" />
+                    </Grid.RowDefinitions>
+                    <Grid Grid.Row="0"
+                          Background="{DynamicResource MaterialDesign.Brush.SurfaceContainerHigh}">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="120" />
+                            <ColumnDefinition Width="120" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Text="{Binding PathHeader}"
+                                   Style="{StaticResource MaterialDesignLabelLargeTextBlock}"
+                                   Margin="{StaticResource XSmallMargin}"
+                                   VerticalAlignment="Center" />
+                        <TextBlock Grid.Column="1"
+                                   Text="{Binding RepositoryHeader}"
+                                   Style="{StaticResource MaterialDesignLabelLargeTextBlock}"
+                                   Margin="{StaticResource XSmallMargin}"
+                                   HorizontalAlignment="Center"
+                                   VerticalAlignment="Center" />
+                        <TextBlock Grid.Column="2"
+                                   Text="{Binding LocalHeader}"
+                                   Style="{StaticResource MaterialDesignLabelLargeTextBlock}"
+                                   Margin="{StaticResource XSmallMargin}"
+                                   HorizontalAlignment="Center"
+                                   VerticalAlignment="Center" />
+                    </Grid>
+                    <ScrollViewer Grid.Row="1"
+                                  VerticalScrollBarVisibility="Auto">
+                        <ItemsControl x:Name="SelectionItemsControl"
+                                      ItemsSource="{Binding Items}">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate>
+                                    <Border BorderBrush="{DynamicResource MaterialDesign.Brush.OutlineVariant}"
+                                            BorderThickness="0,0,0,1">
+                                        <Grid Margin="{StaticResource XSmallMargin}">
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="*" />
+                                                <ColumnDefinition Width="120" />
+                                                <ColumnDefinition Width="120" />
+                                            </Grid.ColumnDefinitions>
+                                            <TextBlock Text="{Binding Path}"
+                                                       TextWrapping="Wrap"
+                                                       VerticalAlignment="Center" />
+                                            <RadioButton Grid.Column="1"
+                                                         IsChecked="{Binding IsRepositorySelected, Mode=TwoWay}"
+                                                         GroupName="{Binding GroupName}"
+                                                         HorizontalAlignment="Center"
+                                                         VerticalAlignment="Center" />
+                                            <RadioButton Grid.Column="2"
+                                                         IsChecked="{Binding IsLocalSelected, Mode=TwoWay}"
+                                                         GroupName="{Binding GroupName}"
+                                                         HorizontalAlignment="Center"
+                                                         VerticalAlignment="Center" />
+                                        </Grid>
+                                    </Border>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </ScrollViewer>
+                </Grid>
+            </Border>
+
+            <StackPanel Grid.Row="2"
+                        Orientation="Horizontal"
+                        HorizontalAlignment="Right">
+                <Button x:Name="ConfirmButton"
+                        Click="OnConfirmClick"
+                        Content="{Binding ConfirmButtonText}"
+                        Style="{StaticResource MaterialDesignRaisedButton}"
+                        Margin="{StaticResource XSmallRightMargin}" />
+                <Button x:Name="CancelButton"
+                        Command="{x:Static md:DialogHost.CloseDialogCommand}"
+                        Content="{Binding CancelButtonText}"
+                        Style="{StaticResource MaterialDesignRaisedButton}" />
+            </StackPanel>
+        </Grid>
+    </Border>
+</UserControl>

--- a/src/DcsTranslationTool.Presentation.Wpf/UI/Dialogs/Views/DownloadModifiedApplySelectionDialog.xaml.cs
+++ b/src/DcsTranslationTool.Presentation.Wpf/UI/Dialogs/Views/DownloadModifiedApplySelectionDialog.xaml.cs
@@ -1,0 +1,37 @@
+using System.Windows;
+using System.Windows.Controls;
+
+using DcsTranslationTool.Presentation.Wpf.UI.Dialogs.Parameters;
+
+using MaterialDesignThemes.Wpf;
+
+namespace DcsTranslationTool.Presentation.Wpf.UI.Dialogs.Views;
+
+/// <summary>
+/// DownloadModifiedApplySelectionDialog.xaml の相互作用ロジックを提供する。
+/// </summary>
+public partial class DownloadModifiedApplySelectionDialog : UserControl {
+    /// <summary>
+    /// DownloadModifiedApplySelectionDialog の新しいインスタンスを初期化する。
+    /// </summary>
+    public DownloadModifiedApplySelectionDialog() {
+        InitializeComponent();
+    }
+
+    /// <summary>
+    /// 確定クリック時に現在の選択結果でダイアログを閉じる。
+    /// </summary>
+    /// <param name="sender">イベント発生元。</param>
+    /// <param name="e">イベント引数。</param>
+    private void OnConfirmClick( object sender, RoutedEventArgs e ) {
+        _ = sender;
+        _ = e;
+
+        if(this.DataContext is not DownloadModifiedApplySelectionDialogParameters parameters) {
+            DialogHost.CloseDialogCommand.Execute( null, this );
+            return;
+        }
+
+        DialogHost.CloseDialogCommand.Execute( parameters.CreateResult(), this );
+    }
+}

--- a/src/DcsTranslationTool.Presentation.Wpf/ViewModels/FileEntryViewModel.cs
+++ b/src/DcsTranslationTool.Presentation.Wpf/ViewModels/FileEntryViewModel.cs
@@ -93,7 +93,6 @@ public class FileEntryViewModel(
     {
         (ChangeTypeMode.Upload, FileChangeType.Unchanged ) => false,
         (ChangeTypeMode.Download, FileChangeType.Unchanged ) => false,
-        (ChangeTypeMode.Download, FileChangeType.LocalOnly ) => false,
         _ => true,
     };
 

--- a/src/DcsTranslationTool.Resources/Strings.Download.Designer.cs
+++ b/src/DcsTranslationTool.Resources/Strings.Download.Designer.cs
@@ -133,6 +133,123 @@ namespace DcsTranslationTool.Resources {
         }
         
         /// <summary>
+        ///   全てローカル版を適用 に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string ModifiedApplyModeDialogApplyAllLocalButtonText {
+            get {
+                return ResourceManager.GetString("ModifiedApplyModeDialogApplyAllLocalButtonText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   全てサーバー版を適用 に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string ModifiedApplyModeDialogApplyAllRepositoryButtonText {
+            get {
+                return ResourceManager.GetString("ModifiedApplyModeDialogApplyAllRepositoryButtonText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   中止 に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string ModifiedApplyModeDialogCancelButtonText {
+            get {
+                return ResourceManager.GetString("ModifiedApplyModeDialogCancelButtonText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   差分があるファイルが {0} 件含まれます。適用方法を選択してください。 に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string ModifiedApplyModeDialogMessage {
+            get {
+                return ResourceManager.GetString("ModifiedApplyModeDialogMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   個別に選択する に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string ModifiedApplyModeDialogSelectIndividuallyButtonText {
+            get {
+                return ResourceManager.GetString("ModifiedApplyModeDialogSelectIndividuallyButtonText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   差分ファイルの適用方法 に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string ModifiedApplyModeDialogTitle {
+            get {
+                return ResourceManager.GetString("ModifiedApplyModeDialogTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   中止 に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string ModifiedApplySelectionDialogCancelButtonText {
+            get {
+                return ResourceManager.GetString("ModifiedApplySelectionDialogCancelButtonText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   決定 に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string ModifiedApplySelectionDialogConfirmButtonText {
+            get {
+                return ResourceManager.GetString("ModifiedApplySelectionDialogConfirmButtonText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   ローカル版 に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string ModifiedApplySelectionDialogLocalHeader {
+            get {
+                return ResourceManager.GetString("ModifiedApplySelectionDialogLocalHeader", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   差分ファイルごとに適用元を選択してください。初期値は全てローカル版です。 に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string ModifiedApplySelectionDialogMessage {
+            get {
+                return ResourceManager.GetString("ModifiedApplySelectionDialogMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   ファイル に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string ModifiedApplySelectionDialogPathHeader {
+            get {
+                return ResourceManager.GetString("ModifiedApplySelectionDialogPathHeader", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   サーバー版 に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string ModifiedApplySelectionDialogRepositoryHeader {
+            get {
+                return ResourceManager.GetString("ModifiedApplySelectionDialogRepositoryHeader", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   差分ファイルの個別選択 に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string ModifiedApplySelectionDialogTitle {
+            get {
+                return ResourceManager.GetString("ModifiedApplySelectionDialogTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   フォルダ に類似しているローカライズされた文字列を検索します。
         /// </summary>
         public static string OpenDirectoryButtonContent {

--- a/src/DcsTranslationTool.Resources/Strings.Download.resx
+++ b/src/DcsTranslationTool.Resources/Strings.Download.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 

--- a/src/DcsTranslationTool.Resources/Strings.Download.resx
+++ b/src/DcsTranslationTool.Resources/Strings.Download.resx
@@ -141,6 +141,45 @@
   <data name="FilterUnchangedText" xml:space="preserve">
     <value>DL済</value>
   </data>
+  <data name="ModifiedApplyModeDialogApplyAllLocalButtonText" xml:space="preserve">
+    <value>全てローカル版を適用</value>
+  </data>
+  <data name="ModifiedApplyModeDialogApplyAllRepositoryButtonText" xml:space="preserve">
+    <value>全てサーバー版を適用</value>
+  </data>
+  <data name="ModifiedApplyModeDialogCancelButtonText" xml:space="preserve">
+    <value>中止</value>
+  </data>
+  <data name="ModifiedApplyModeDialogMessage" xml:space="preserve">
+    <value>差分があるファイルが {0} 件含まれます。適用方法を選択してください。</value>
+  </data>
+  <data name="ModifiedApplyModeDialogSelectIndividuallyButtonText" xml:space="preserve">
+    <value>個別に選択する</value>
+  </data>
+  <data name="ModifiedApplyModeDialogTitle" xml:space="preserve">
+    <value>差分ファイルの適用方法</value>
+  </data>
+  <data name="ModifiedApplySelectionDialogCancelButtonText" xml:space="preserve">
+    <value>中止</value>
+  </data>
+  <data name="ModifiedApplySelectionDialogConfirmButtonText" xml:space="preserve">
+    <value>決定</value>
+  </data>
+  <data name="ModifiedApplySelectionDialogLocalHeader" xml:space="preserve">
+    <value>ローカル版</value>
+  </data>
+  <data name="ModifiedApplySelectionDialogMessage" xml:space="preserve">
+    <value>差分ファイルごとに適用元を選択してください。初期値は全てローカル版です。</value>
+  </data>
+  <data name="ModifiedApplySelectionDialogPathHeader" xml:space="preserve">
+    <value>ファイル</value>
+  </data>
+  <data name="ModifiedApplySelectionDialogRepositoryHeader" xml:space="preserve">
+    <value>サーバー版</value>
+  </data>
+  <data name="ModifiedApplySelectionDialogTitle" xml:space="preserve">
+    <value>差分ファイルの個別選択</value>
+  </data>
   <data name="OpenDirectoryButtonContent" xml:space="preserve">
     <value>フォルダ</value>
   </data>

--- a/tests/DcsTranslationTool.Presentation.Wpf.UnitTests/Features/Download/DownloadViewModelTests.cs
+++ b/tests/DcsTranslationTool.Presentation.Wpf.UnitTests/Features/Download/DownloadViewModelTests.cs
@@ -1,9 +1,12 @@
 using DcsTranslationTool.Application.Contracts;
 using DcsTranslationTool.Application.Interfaces;
 using DcsTranslationTool.Application.Results;
+using DcsTranslationTool.Domain.Models;
 using DcsTranslationTool.Presentation.Wpf.Features.Download;
 using DcsTranslationTool.Presentation.Wpf.Services;
 using DcsTranslationTool.Presentation.Wpf.Services.Abstractions;
+using DcsTranslationTool.Presentation.Wpf.UI.Dialogs.Parameters;
+using DcsTranslationTool.Presentation.Wpf.UI.Dialogs.Results;
 using DcsTranslationTool.Presentation.Wpf.UI.Enums;
 using DcsTranslationTool.Presentation.Wpf.UI.Interfaces;
 using DcsTranslationTool.Shared.Models;
@@ -25,170 +28,7 @@ public sealed class DownloadViewModelTests : IDisposable {
         Directory.CreateDirectory( _tempDir );
     }
 
-    ///// <summary>Applyを呼び出すとRepoOnlyエントリを trk へ適用する。</summary>
-    //[StaFact]
-    //public async Task Applyを呼び出すとRepoOnlyエントリをtrkへ適用する() {
-    //    var sourceRoot = Path.Combine( _tempDir, "AircraftSourceTrk" );
-    //    var trkDirectory = Path.Combine( sourceRoot, "A10C", "Missions", "EN" );
-    //    Directory.CreateDirectory( trkDirectory );
-    //    var trkPath = Path.Combine( trkDirectory, "Example.trk" );
-    //    File.WriteAllBytes( trkPath, [] );
 
-    //    var appSettings = new AppSettings
-    //    {
-    //        TranslateFileDir = _tempDir,
-    //        SourceAircraftDir = sourceRoot
-    //    };
-    //    const string repoEntryPath = "DCSWorld/Mods/aircraft/A10C/Missions/EN/Example.trk/Localization/Example.lua";
-    //    const string fileContent = "trk内に適用する";
-
-    //    var repoEntry = new RepoFileEntry( "Example.lua", repoEntryPath, false, repoSha: "deadc0de" );
-    //    var treeResult = Result.Ok<IReadOnlyList<FileEntry>>( [repoEntry] );
-
-    //    byte[] archiveBytes = CreateZipForApply(
-    //        (repoEntryPath, fileContent)
-    //    );
-    //    var downloadResult = Result.Ok(
-    //        new ApiDownloadFilesResult(
-    //            [repoEntryPath],
-    //            archiveBytes,
-    //            archiveBytes.Length,
-    //            "application/zip",
-    //            "apply-trk.zip",
-    //            "\"apply-trk-etag\"",
-    //            false
-    //        )
-    //    );
-
-    //    var apiServiceMock = new Mock<IApiService>( MockBehavior.Strict );
-    //    apiServiceMock
-    //        .Setup( service => service.GetTreeAsync( It.IsAny<CancellationToken>() ) )
-    //        .ReturnsAsync( treeResult );
-    //    apiServiceMock
-    //        .Setup( service => service.DownloadFilesAsync(
-    //            It.Is<ApiDownloadFilesRequest>( request =>
-    //                request.Paths.Count == 1 &&
-    //                request.Paths[0] == repoEntryPath &&
-    //                request.ETag == null
-    //            ),
-    //            It.IsAny<CancellationToken>()
-    //        ) )
-    //        .ReturnsAsync( downloadResult );
-
-    //    var dispatcherServiceMock = new Mock<IDispatcherService>();
-    //    dispatcherServiceMock
-    //        .Setup( service => service.InvokeAsync( It.IsAny<Func<Task>>() ) )
-    //        .Returns<Func<Task>>( func => func() );
-
-    //    var appSettingsServiceMock = new Mock<IAppSettingsService>();
-    //    appSettingsServiceMock
-    //        .SetupGet( service => service.Settings )
-    //        .Returns( appSettings );
-
-    //    var fileEntryServiceMock = new Mock<IFileEntryService>();
-    //    fileEntryServiceMock
-    //        .Setup( service => service.GetEntriesAsync() )
-    //        .ReturnsAsync( Result.Ok<IReadOnlyList<FileEntry>>( Array.Empty<FileEntry>() ) );
-    //    var loggingServiceMock = new Mock<ILoggingService>();
-    //    var snackbarMessages = new List<string>();
-    //    var snackbarMessageQueueMock = new Mock<ISnackbarMessageQueue>();
-    //    var snackbarServiceMock = new Mock<ISnackbarService>();
-    //    snackbarServiceMock
-    //        .SetupGet( service => service.MessageQueue )
-    //        .Returns( snackbarMessageQueueMock.Object );
-    //    snackbarServiceMock
-    //        .Setup( service => service.Show(
-    //            It.IsAny<string>(),
-    //            It.IsAny<string?>(),
-    //            It.IsAny<Action?>(),
-    //            It.IsAny<object?>(),
-    //            It.IsAny<TimeSpan?>()
-    //        ) )
-    //        .Callback<string, string?, Action?, object?, TimeSpan?>(
-    //            ( message, _, _, _, _ ) => snackbarMessages.Add( message )
-    //        );
-
-    //    var systemServiceMock = new Mock<ISystemService>( MockBehavior.Strict );
-
-    //    var zipServiceMock = new Mock<IZipService>( MockBehavior.Strict );
-    //    zipServiceMock
-    //        .Setup( service => service.AddEntry(
-    //            It.Is<string>( value => string.Equals( value, trkPath, StringComparison.OrdinalIgnoreCase ) ),
-    //            "Localization/Example.lua",
-    //            It.Is<string>( value => string.Equals(
-    //                value,
-    //                Path.Combine(
-    //                    _tempDir,
-    //                    "DCSWorld",
-    //                    "Mods",
-    //                    "aircraft",
-    //                    "A10C",
-    //                    "Missions",
-    //                    "EN",
-    //                    "Example.trk",
-    //                    "Localization",
-    //                    "Example.lua"
-    //                ),
-    //                StringComparison.OrdinalIgnoreCase ) )
-    //        ) )
-    //        .Returns( Result.Ok );
-
-    //    var viewModel = new DownloadViewModel(
-    //        apiServiceMock.Object,
-    //        appSettingsServiceMock.Object,
-    //        dispatcherServiceMock.Object,
-    //        fileEntryServiceMock.Object,
-    //        loggingServiceMock.Object,
-    //        snackbarServiceMock.Object,
-    //        systemServiceMock.Object,
-    //        zipServiceMock.Object
-    //    );
-
-    //    await viewModel.Fetch();
-    //    var aircraftIndex = viewModel.Tabs
-    //        .Select( ( tab, index ) => ( tab, index ) )
-    //        .First( pair => pair.tab.TabType == CategoryType.Aircraft )
-    //        .index;
-    //    viewModel.SelectedTabIndex = aircraftIndex;
-
-    //    var aircraftRoot = viewModel.Tabs[aircraftIndex].Root;
-    //    var fileNode = FindNodeByPath( aircraftRoot, "A10C", "Missions", "EN", "Example.trk", "Localization", "Example.lua" );
-    //    Assert.NotNull( fileNode );
-    //    fileNode!.CheckState = true;
-
-    //    Assert.True( viewModel.CanApply );
-
-    //    await viewModel.Apply();
-
-    //    var manifestPath = Path.Combine( _tempDir, "manifest.json" );
-    //    Assert.False( File.Exists( manifestPath ) );
-
-    //    var expectedTranslationPath = Path.Combine(
-    //        _tempDir,
-    //        "DCSWorld",
-    //        "Mods",
-    //        "aircraft",
-    //        "A10C",
-    //        "Missions",
-    //        "EN",
-    //        "Example.trk",
-    //        "Localization",
-    //        "Example.lua"
-    //    );
-    //    Assert.True( File.Exists( expectedTranslationPath ) );
-    //    Assert.Equal( fileContent, File.ReadAllText( expectedTranslationPath, Encoding.UTF8 ) );
-    //    zipServiceMock.Verify( service => service.AddEntry(
-    //        It.Is<string>( value => string.Equals( value, trkPath, StringComparison.OrdinalIgnoreCase ) ),
-    //        "Localization/Example.lua",
-    //        It.IsAny<string>()
-    //    ), Times.Once );
-    //    Assert.Contains( snackbarMessages, message => message == "適用完了 成功:1 件 失敗:0 件" );
-    //    Assert.Equal( 100, viewModel.AppliedProgress );
-    //    Assert.True( viewModel.CanApply );
-
-    //    apiServiceMock.VerifyAll();
-    //    zipServiceMock.VerifyAll();
-    //}
 
     public void Dispose() {
         if(Directory.Exists( _tempDir )) {
@@ -270,10 +110,12 @@ public sealed class DownloadViewModelTests : IDisposable {
             fileEntryServiceMock.Object,
             loggingServiceMock.Object
         );
+        var dialogServiceMock = new Mock<IDialogService>( MockBehavior.Strict );
 
         var viewModel = new DownloadViewModel(
             apiServiceMock.Object,
             appSettingsServiceMock.Object,
+            dialogServiceMock.Object,
             downloadWorkflowService,
             dispatcherServiceMock.Object,
             fileEntryServiceMock.Object,
@@ -355,10 +197,12 @@ public sealed class DownloadViewModelTests : IDisposable {
         var downloadWorkflowServiceMock = new Mock<IDownloadWorkflowService>( MockBehavior.Strict );
         var fileEntryWatcherLifecycleMock = new Mock<IFileEntryWatcherLifecycle>( MockBehavior.Strict );
         var fileEntryTreeService = new FileEntryTreeService( loggingServiceMock.Object );
+        var dialogServiceMock = new Mock<IDialogService>( MockBehavior.Strict );
 
         var viewModel = new DownloadViewModel(
             apiServiceMock.Object,
             appSettingsServiceMock.Object,
+            dialogServiceMock.Object,
             downloadWorkflowServiceMock.Object,
             dispatcherServiceMock.Object,
             fileEntryServiceMock.Object,
@@ -397,242 +241,6 @@ public sealed class DownloadViewModelTests : IDisposable {
         apiServiceMock.VerifyAll();
     }
 
-    ///// <summary>一部のファイルがダウンロード失敗した場合に失敗件数を通知することを確認する。</summary>
-    //[StaFact]
-    //public async Task Downloadを呼び出すと一部のファイル保存に失敗すると失敗分を通知する() {
-    //    var appSettings = new AppSettings { TranslateFileDir = _tempDir };
-    //    const string validRepoEntryPath = "DCSWorld/Mods/aircraft/A10C/L10N/Valid.lua";
-    //    const string invalidRepoEntryPath = "DCSWorld/Mods/aircraft/A10C/L10N/Broken.lua";
-    //    const string validContent = "正常系";
-
-    //    var repoEntries = new List<FileEntry> {
-    //        new RepoFileEntry( "Valid.lua", validRepoEntryPath, false, repoSha: "deadbeef" ),
-    //        new RepoFileEntry( "Broken.lua", invalidRepoEntryPath, false, repoSha: "badd00d" )
-    //    };
-    //    var treeResult = Result.Ok<IReadOnlyList<FileEntry>>( repoEntries );
-
-    //    var downloadResult = Result.Ok(
-    //        new ApiDownloadFilePathsResult(
-    //            new[]
-    //            {
-    //                new ApiDownloadFilePathsItem( "https://example.test/raw/valid.lua", validRepoEntryPath ),
-    //                new ApiDownloadFilePathsItem( "https://example.test/raw/broken.lua", invalidRepoEntryPath )
-    //            },
-    //            "\"etag-value\""
-    //        )
-    //    );
-
-    //    var apiServiceMock = new Mock<IApiService>( MockBehavior.Strict );
-    //    apiServiceMock
-    //        .Setup( service => service.GetTreeAsync( It.IsAny<CancellationToken>() ) )
-    //        .ReturnsAsync( treeResult );
-    //    apiServiceMock
-    //        .Setup( service => service.DownloadFilePathsAsync(
-    //            It.Is<ApiDownloadFilePathsRequest>( request =>
-    //                request.Paths.Count == 2 &&
-    //                request.Paths.Contains( validRepoEntryPath ) &&
-    //                request.Paths.Contains( invalidRepoEntryPath ) &&
-    //                request.ETag == null
-    //            ),
-    //            It.IsAny<CancellationToken>()
-    //        ) )
-    //        .ReturnsAsync( downloadResult );
-
-    //    var dispatcherServiceMock = new Mock<IDispatcherService>();
-    //    dispatcherServiceMock
-    //        .Setup( service => service.InvokeAsync( It.IsAny<Func<Task>>() ) )
-    //        .Returns<Func<Task>>( func => func() );
-
-    //    var appSettingsServiceMock = new Mock<IAppSettingsService>();
-    //    appSettingsServiceMock
-    //        .SetupGet( service => service.Settings )
-    //        .Returns( appSettings );
-
-    //    var fileEntryServiceMock = new Mock<IFileEntryService>();
-    //    var loggingServiceMock = new Mock<ILoggingService>();
-    //    var snackbarMessages = new List<string>();
-    //    var snackbarMessageQueueMock = new Mock<ISnackbarMessageQueue>();
-    //    var snackbarServiceMock = new Mock<ISnackbarService>();
-    //    snackbarServiceMock
-    //        .SetupGet( service => service.MessageQueue )
-    //        .Returns( snackbarMessageQueueMock.Object );
-    //    snackbarServiceMock
-    //        .Setup( service => service.Show(
-    //            It.IsAny<string>(),
-    //            It.IsAny<string?>(),
-    //            It.IsAny<Action?>(),
-    //            It.IsAny<object?>(),
-    //            It.IsAny<TimeSpan?>()
-    //        ) )
-    //        .Callback<string, string?, Action?, object?, TimeSpan?>(
-    //            ( message, _, _, _, _ ) => snackbarMessages.Add( message )
-    //        );
-
-    //    var systemServiceMock = new Mock<ISystemService>( MockBehavior.Strict );
-    //    var zipServiceMock = new Mock<IZipService>( MockBehavior.Strict );
-
-    //    var viewModel = new DownloadViewModel(
-    //        apiServiceMock.Object,
-    //        appSettingsServiceMock.Object,
-    //        dispatcherServiceMock.Object,
-    //        fileEntryServiceMock.Object,
-    //        loggingServiceMock.Object,
-    //        snackbarServiceMock.Object,
-    //        systemServiceMock.Object,
-    //        zipServiceMock.Object
-    //    );
-
-    //    await viewModel.Fetch();
-    //    var aircraftIndex = viewModel.Tabs
-    //        .Select( ( tab, index ) => ( tab, index ) )
-    //        .First( pair => pair.tab.TabType == CategoryType.Aircraft )
-    //        .index;
-    //    viewModel.SelectedTabIndex = aircraftIndex;
-
-    //    var aircraftRoot = viewModel.Tabs[aircraftIndex].Root;
-    //    var validNode = FindNodeByPath( aircraftRoot, "A10C", "L10N", "Valid.lua" );
-    //    var invalidNode = FindNodeByPath( aircraftRoot, "A10C", "L10N", "Broken.lua" );
-    //    Assert.NotNull( validNode );
-    //    Assert.NotNull( invalidNode );
-    //    validNode!.CheckState = true;
-    //    invalidNode!.CheckState = true;
-
-    //    Assert.True( viewModel.CanDownload );
-
-    //    await viewModel.Download();
-
-    //    var validFilePath = Path.Combine( _tempDir, "DCSWorld", "Mods", "aircraft", "A10C", "L10N", "Valid.lua" );
-    //    var invalidFilePath = Path.Combine( _tempDir, "DCSWorld", "Mods", "aircraft", "A10C", "L10N", "Broken.lua" );
-    //    Assert.True( File.Exists( validFilePath ) );
-    //    Assert.Equal( validContent, File.ReadAllText( validFilePath, Encoding.UTF8 ) );
-    //    Assert.False( File.Exists( invalidFilePath ) );
-    //    Assert.Contains( snackbarMessages, message => message == "一部のファイルの保存に失敗しました (1/2)" );
-    //    Assert.Equal( 100, viewModel.DownloadedProgress );
-    //    Assert.True( viewModel.CanDownload );
-
-    //    apiServiceMock.VerifyAll();
-    //}
-
-    ///// <summary>一部のファイルで検証が失敗した場合に成功分のみが保存されることを確認する。</summary>
-    //[StaFact]
-    //public async Task Downloadを呼び出すと一部のファイル保存に失敗すると失敗分を通知する() {
-    //    var appSettings = new AppSettings { TranslateFileDir = _tempDir };
-    //    const string validRepoEntryPath = "DCSWorld/Mods/aircraft/A10C/L10N/Valid.lua";
-    //    const string invalidRepoEntryPath = "DCSWorld/Mods/aircraft/A10C/L10N/Broken.lua";
-    //    const string validContent = "正常系";
-
-    //    var repoEntries = new List<FileEntry> {
-    //        new RepoFileEntry( "Valid.lua", validRepoEntryPath, false, repoSha: "deadbeef" ),
-    //        new RepoFileEntry( "Broken.lua", invalidRepoEntryPath, false, repoSha: "badd00d" )
-    //    };
-    //    var treeResult = Result.Ok<IReadOnlyList<FileEntry>>( repoEntries );
-
-    //    byte[] archiveBytes = CreateZipWithManifest(
-    //        new ManifestEntryTestData( validRepoEntryPath, validContent ),
-    //        new ManifestEntryTestData( invalidRepoEntryPath, "破損データ", DeclaredSize: 1 )
-    //    );
-    //    var downloadResult = Result.Ok(
-    //        new ApiDownloadFilesResult(
-    //            [validRepoEntryPath, invalidRepoEntryPath],
-    //            archiveBytes,
-    //            archiveBytes.Length,
-    //            "application/zip",
-    //            "test.zip",
-    //            "\"etag-value\"",
-    //            false
-    //        )
-    //    );
-
-    //    var apiServiceMock = new Mock<IApiService>( MockBehavior.Strict );
-    //    apiServiceMock
-    //        .Setup( service => service.GetTreeAsync( It.IsAny<CancellationToken>() ) )
-    //        .ReturnsAsync( treeResult );
-    //    apiServiceMock
-    //        .Setup( service => service.DownloadFilesAsync(
-    //            It.Is<ApiDownloadFilesRequest>( request =>
-    //                request.Paths.Count == 2 &&
-    //                request.Paths.Contains( validRepoEntryPath ) &&
-    //                request.Paths.Contains( invalidRepoEntryPath ) &&
-    //                request.ETag == null
-    //            ),
-    //            It.IsAny<CancellationToken>()
-    //        ) )
-    //        .ReturnsAsync( downloadResult );
-
-    //    var dispatcherServiceMock = new Mock<IDispatcherService>();
-    //    dispatcherServiceMock
-    //        .Setup( service => service.InvokeAsync( It.IsAny<Func<Task>>() ) )
-    //        .Returns<Func<Task>>( func => func() );
-
-    //    var appSettingsServiceMock = new Mock<IAppSettingsService>();
-    //    appSettingsServiceMock
-    //        .SetupGet( service => service.Settings )
-    //        .Returns( appSettings );
-
-    //    var fileEntryServiceMock = new Mock<IFileEntryService>();
-    //    var loggingServiceMock = new Mock<ILoggingService>();
-    //    var snackbarMessages = new List<string>();
-    //    var snackbarMessageQueueMock = new Mock<ISnackbarMessageQueue>();
-    //    var snackbarServiceMock = new Mock<ISnackbarService>();
-    //    snackbarServiceMock
-    //        .SetupGet( service => service.MessageQueue )
-    //        .Returns( snackbarMessageQueueMock.Object );
-    //    snackbarServiceMock
-    //        .Setup( service => service.Show(
-    //            It.IsAny<string>(),
-    //            It.IsAny<string?>(),
-    //            It.IsAny<Action?>(),
-    //            It.IsAny<object?>(),
-    //            It.IsAny<TimeSpan?>()
-    //        ) )
-    //        .Callback<string, string?, Action?, object?, TimeSpan?>(
-    //            ( message, _, _, _, _ ) => snackbarMessages.Add( message )
-    //        );
-
-    //    var systemServiceMock = new Mock<ISystemService>( MockBehavior.Strict );
-    //    var zipServiceMock = new Mock<IZipService>( MockBehavior.Strict );
-
-    //    var viewModel = new DownloadViewModel(
-    //        apiServiceMock.Object,
-    //        appSettingsServiceMock.Object,
-    //        dispatcherServiceMock.Object,
-    //        fileEntryServiceMock.Object,
-    //        loggingServiceMock.Object,
-    //        snackbarServiceMock.Object,
-    //        systemServiceMock.Object,
-    //        zipServiceMock.Object
-    //    );
-
-    //    await viewModel.Fetch();
-    //    var aircraftIndex = viewModel.Tabs
-    //        .Select( ( tab, index ) => ( tab, index ) )
-    //        .First( pair => pair.tab.TabType == CategoryType.Aircraft )
-    //        .index;
-    //    viewModel.SelectedTabIndex = aircraftIndex;
-
-    //    var aircraftRoot = viewModel.Tabs[aircraftIndex].Root;
-    //    var validNode = FindNodeByPath( aircraftRoot, "A10C", "L10N", "Valid.lua" );
-    //    var invalidNode = FindNodeByPath( aircraftRoot, "A10C", "L10N", "Broken.lua" );
-    //    Assert.NotNull( validNode );
-    //    Assert.NotNull( invalidNode );
-    //    validNode!.CheckState = true;
-    //    invalidNode!.CheckState = true;
-
-    //    Assert.True( viewModel.CanDownload );
-
-    //    await viewModel.Download();
-
-    //    var validFilePath = Path.Combine( _tempDir, "DCSWorld", "Mods", "aircraft", "A10C", "L10N", "Valid.lua" );
-    //    var invalidFilePath = Path.Combine( _tempDir, "DCSWorld", "Mods", "aircraft", "A10C", "L10N", "Broken.lua" );
-    //    Assert.True( File.Exists( validFilePath ) );
-    //    Assert.Equal( validContent, File.ReadAllText( validFilePath, Encoding.UTF8 ) );
-    //    Assert.False( File.Exists( invalidFilePath ) );
-    //    Assert.Contains( snackbarMessages, message => message == "一部のファイルの保存に失敗しました (1/2)" );
-    //    Assert.Equal( 100, viewModel.DownloadedProgress );
-    //    Assert.True( viewModel.CanDownload );
-
-    //    apiServiceMock.VerifyAll();
-    //}
 
     /// <summary>変更が無い場合にダウンロードをスキップすることを確認する。</summary>
     [StaFact]
@@ -707,10 +315,12 @@ public sealed class DownloadViewModelTests : IDisposable {
             fileEntryServiceMock.Object,
             loggingServiceMock.Object
         );
+        var dialogServiceMock = new Mock<IDialogService>( MockBehavior.Strict );
 
         var viewModel = new DownloadViewModel(
             apiServiceMock.Object,
             appSettingsServiceMock.Object,
+            dialogServiceMock.Object,
             downloadWorkflowService,
             dispatcherServiceMock.Object,
             fileEntryServiceMock.Object,
@@ -801,6 +411,7 @@ public sealed class DownloadViewModelTests : IDisposable {
         var downloadWorkflowServiceMock = new Mock<IDownloadWorkflowService>( MockBehavior.Strict );
         var fileEntryWatcherLifecycleMock = new Mock<IFileEntryWatcherLifecycle>( MockBehavior.Strict );
         var fileEntryTreeService = new FileEntryTreeService( loggingServiceMock.Object );
+        var dialogServiceMock = new Mock<IDialogService>( MockBehavior.Strict );
 
         downloadWorkflowServiceMock
             .Setup( service => service.ExecuteApplyAsync(
@@ -814,6 +425,7 @@ public sealed class DownloadViewModelTests : IDisposable {
         var viewModel = new DownloadViewModel(
             apiServiceMock.Object,
             appSettingsServiceMock.Object,
+            dialogServiceMock.Object,
             downloadWorkflowServiceMock.Object,
             dispatcherServiceMock.Object,
             fileEntryServiceMock.Object,
@@ -848,721 +460,556 @@ public sealed class DownloadViewModelTests : IDisposable {
         apiServiceMock.Verify( service => service.GetTreeAsync( It.IsAny<CancellationToken>() ), Times.Once );
     }
 
-    ///// <summary>Applyを呼び出すとRepoOnlyエントリを miz へ適用する。</summary>
-    //[StaFact]
-    //public async Task Applyを呼び出すとRepoOnlyエントリをmizへ適用する() {
-    //    var sourceRoot = Path.Combine( _tempDir, "AircraftSource" );
-    //    var mizDirectory = Path.Combine( sourceRoot, "A10C", "Missions", "EN" );
-    //    Directory.CreateDirectory( mizDirectory );
-    //    var mizPath = Path.Combine( mizDirectory, "Example.miz" );
-    //    File.WriteAllBytes( mizPath, [] );
-
-    //    var appSettings = new AppSettings
-    //    {
-    //        TranslateFileDir = _tempDir,
-    //        SourceAircraftDir = sourceRoot
-    //    };
-    //    const string repoEntryPath = "DCSWorld/Mods/aircraft/A10C/Missions/EN/Example.miz/Localization/Example.lua";
-    //    const string fileContent = "miz内に適用する";
-
-    //    var repoEntry = new RepoFileEntry( "Example.lua", repoEntryPath, false, repoSha: "cafefade" );
-    //    var treeResult = Result.Ok<IReadOnlyList<FileEntry>>( [repoEntry] );
-
-    //    byte[] archiveBytes = CreateZipForApply(
-    //        (repoEntryPath, fileContent)
-    //    );
-    //    var downloadResult = Result.Ok(
-    //        new ApiDownloadFilesResult(
-    //            [repoEntryPath],
-    //            archiveBytes,
-    //            archiveBytes.Length,
-    //            "application/zip",
-    //            "apply.zip",
-    //            "\"apply-etag\"",
-    //            false
-    //        )
-    //    );
-
-    //    var apiServiceMock = new Mock<IApiService>( MockBehavior.Strict );
-    //    apiServiceMock
-    //        .Setup( service => service.GetTreeAsync( It.IsAny<CancellationToken>() ) )
-    //        .ReturnsAsync( treeResult );
-    //    apiServiceMock
-    //        .Setup( service => service.DownloadFilesAsync(
-    //            It.Is<ApiDownloadFilesRequest>( request =>
-    //                request.Paths.Count == 1 &&
-    //                request.Paths[0] == repoEntryPath &&
-    //                request.ETag == null
-    //            ),
-    //            It.IsAny<CancellationToken>()
-    //        ) )
-    //        .ReturnsAsync( downloadResult );
-
-    //    var dispatcherServiceMock = new Mock<IDispatcherService>();
-    //    dispatcherServiceMock
-    //        .Setup( service => service.InvokeAsync( It.IsAny<Func<Task>>() ) )
-    //        .Returns<Func<Task>>( func => func() );
-
-    //    var appSettingsServiceMock = new Mock<IAppSettingsService>();
-    //    appSettingsServiceMock
-    //        .SetupGet( service => service.Settings )
-    //        .Returns( appSettings );
-
-    //    var fileEntryServiceMock = new Mock<IFileEntryService>();
-    //    var loggingServiceMock = new Mock<ILoggingService>();
-    //    var snackbarMessages = new List<string>();
-    //    var snackbarMessageQueueMock = new Mock<ISnackbarMessageQueue>();
-    //    var snackbarServiceMock = new Mock<ISnackbarService>();
-    //    snackbarServiceMock
-    //        .SetupGet( service => service.MessageQueue )
-    //        .Returns( snackbarMessageQueueMock.Object );
-    //    snackbarServiceMock
-    //        .Setup( service => service.Show(
-    //            It.IsAny<string>(),
-    //            It.IsAny<string?>(),
-    //            It.IsAny<Action?>(),
-    //            It.IsAny<object?>(),
-    //            It.IsAny<TimeSpan?>()
-    //        ) )
-    //        .Callback<string, string?, Action?, object?, TimeSpan?>(
-    //            ( message, _, _, _, _ ) => snackbarMessages.Add( message )
-    //        );
-
-    //    var systemServiceMock = new Mock<ISystemService>( MockBehavior.Strict );
-
-    //    var zipServiceMock = new Mock<IZipService>( MockBehavior.Strict );
-    //    zipServiceMock
-    //        .Setup( service => service.AddEntry(
-    //            It.Is<string>( value => string.Equals( value, mizPath, StringComparison.OrdinalIgnoreCase ) ),
-    //            "Localization/Example.lua",
-    //            It.Is<string>( value => string.Equals(
-    //                value,
-    //                Path.Combine(
-    //                    _tempDir,
-    //                    "DCSWorld",
-    //                    "Mods",
-    //                    "aircraft",
-    //                    "A10C",
-    //                    "Missions",
-    //                    "EN",
-    //                    "Example.miz",
-    //                    "Localization",
-    //                    "Example.lua"
-    //                ),
-    //                StringComparison.OrdinalIgnoreCase ) )
-    //        ) )
-    //        .Returns( Result.Ok );
-
-    //    var viewModel = new DownloadViewModel(
-    //        apiServiceMock.Object,
-    //        appSettingsServiceMock.Object,
-    //        dispatcherServiceMock.Object,
-    //        fileEntryServiceMock.Object,
-    //        loggingServiceMock.Object,
-    //        snackbarServiceMock.Object,
-    //        systemServiceMock.Object,
-    //        zipServiceMock.Object
-    //    );
-
-    //    await viewModel.Fetch();
-    //    var aircraftIndex = viewModel.Tabs
-    //        .Select( ( tab, index ) => ( tab, index ) )
-    //        .First( pair => pair.tab.TabType == CategoryType.Aircraft )
-    //        .index;
-    //    viewModel.SelectedTabIndex = aircraftIndex;
-
-    //    var aircraftRoot = viewModel.Tabs[aircraftIndex].Root;
-    //    var fileNode = FindNodeByPath( aircraftRoot, "A10C", "Missions", "EN", "Example.miz", "Localization", "Example.lua" );
-    //    Assert.NotNull( fileNode );
-    //    fileNode!.CheckState = true;
-
-    //    Assert.True( viewModel.CanApply );
-
-    //    await viewModel.Apply();
-
-    //    var manifestPath = Path.Combine( _tempDir, "manifest.json" );
-    //    Assert.False( File.Exists( manifestPath ) );
-
-    //    var expectedTranslationPath = Path.Combine(
-    //        _tempDir,
-    //        "DCSWorld",
-    //        "Mods",
-    //        "aircraft",
-    //        "A10C",
-    //        "Missions",
-    //        "EN",
-    //        "Example.miz",
-    //        "Localization",
-    //        "Example.lua"
-    //    );
-    //    Assert.True( File.Exists( expectedTranslationPath ) );
-    //    Assert.Equal( fileContent, File.ReadAllText( expectedTranslationPath, Encoding.UTF8 ) );
-    //    zipServiceMock.Verify( service => service.AddEntry(
-    //        It.Is<string>( value => string.Equals( value, mizPath, StringComparison.OrdinalIgnoreCase ) ),
-    //        "Localization/Example.lua",
-    //        It.IsAny<string>()
-    //    ), Times.Once );
-    //    Assert.Contains( snackbarMessages, message => message == "適用完了 成功:1 件 失敗:0 件" );
-    //    Assert.Equal( 100, viewModel.AppliedProgress );
-    //    Assert.True( viewModel.CanApply );
-
-    //    apiServiceMock.VerifyAll();
-    //    zipServiceMock.VerifyAll();
-    //}
-
-    ///// <summary>Applyを呼び出すとmizを含まないエントリはSourceDir配下へコピーする。</summary>
-    //[StaFact]
-    //public async Task Applyを呼び出すとmizを含まないエントリをSourceDirへ保存する() {
-    //    var sourceRoot = Path.Combine( _tempDir, "AircraftSourcePlain" );
-    //    Directory.CreateDirectory( sourceRoot );
-
-    //    var appSettings = new AppSettings
-    //    {
-    //        TranslateFileDir = _tempDir,
-    //        SourceAircraftDir = sourceRoot
-    //    };
-    //    const string repoEntryPath = "DCSWorld/Mods/aircraft/A10C/L10N/Example.lua";
-    //    const string fileContent = "mizなしファイルを保存する";
-
-    //    var repoEntry = new RepoFileEntry( "Example.lua", repoEntryPath, false, repoSha: "plaincafe" );
-    //    var treeResult = Result.Ok<IReadOnlyList<FileEntry>>( [repoEntry] );
-
-    //    byte[] archiveBytes = CreateZipForApply(
-    //        (repoEntryPath, fileContent)
-    //    );
-    //    var downloadResult = Result.Ok(
-    //        new ApiDownloadFilesResult(
-    //            [repoEntryPath],
-    //            archiveBytes,
-    //            archiveBytes.Length,
-    //            "application/zip",
-    //            "apply-plain.zip",
-    //            "\"apply-plain-etag\"",
-    //            false
-    //        )
-    //    );
-
-    //    var apiServiceMock = new Mock<IApiService>( MockBehavior.Strict );
-    //    apiServiceMock
-    //        .Setup( service => service.GetTreeAsync( It.IsAny<CancellationToken>() ) )
-    //        .ReturnsAsync( treeResult );
-    //    apiServiceMock
-    //        .Setup( service => service.DownloadFilesAsync(
-    //            It.Is<ApiDownloadFilesRequest>( request =>
-    //                request.Paths.Count == 1 &&
-    //                request.Paths[0] == repoEntryPath &&
-    //                request.ETag == null
-    //            ),
-    //            It.IsAny<CancellationToken>()
-    //        ) )
-    //        .ReturnsAsync( downloadResult );
-
-    //    var dispatcherServiceMock = new Mock<IDispatcherService>();
-    //    dispatcherServiceMock
-    //        .Setup( service => service.InvokeAsync( It.IsAny<Func<Task>>() ) )
-    //        .Returns<Func<Task>>( func => func() );
-
-    //    var appSettingsServiceMock = new Mock<IAppSettingsService>();
-    //    appSettingsServiceMock
-    //        .SetupGet( service => service.Settings )
-    //        .Returns( appSettings );
-
-    //    var fileEntryServiceMock = new Mock<IFileEntryService>();
-    //    var loggingServiceMock = new Mock<ILoggingService>();
-    //    var snackbarMessages = new List<string>();
-    //    var snackbarMessageQueueMock = new Mock<ISnackbarMessageQueue>();
-    //    var snackbarServiceMock = new Mock<ISnackbarService>();
-    //    snackbarServiceMock
-    //        .SetupGet( service => service.MessageQueue )
-    //        .Returns( snackbarMessageQueueMock.Object );
-    //    snackbarServiceMock
-    //        .Setup( service => service.Show(
-    //            It.IsAny<string>(),
-    //            It.IsAny<string?>(),
-    //            It.IsAny<Action?>(),
-    //            It.IsAny<object?>(),
-    //            It.IsAny<TimeSpan?>()
-    //        ) )
-    //        .Callback<string, string?, Action?, object?, TimeSpan?>(
-    //            ( message, _, _, _, _ ) => snackbarMessages.Add( message )
-    //        );
-
-    //    var systemServiceMock = new Mock<ISystemService>( MockBehavior.Strict );
-    //    var zipServiceMock = new Mock<IZipService>( MockBehavior.Strict );
-
-    //    var viewModel = new DownloadViewModel(
-    //        apiServiceMock.Object,
-    //        appSettingsServiceMock.Object,
-    //        dispatcherServiceMock.Object,
-    //        fileEntryServiceMock.Object,
-    //        loggingServiceMock.Object,
-    //        snackbarServiceMock.Object,
-    //        systemServiceMock.Object,
-    //        zipServiceMock.Object
-    //    );
-
-    //    await viewModel.Fetch();
-    //    var aircraftIndex = viewModel.Tabs
-    //        .Select( ( tab, index ) => ( tab, index ) )
-    //        .First( pair => pair.tab.TabType == CategoryType.Aircraft )
-    //        .index;
-    //    viewModel.SelectedTabIndex = aircraftIndex;
-
-    //    var aircraftRoot = viewModel.Tabs[aircraftIndex].Root;
-    //    var fileNode = FindNodeByPath( aircraftRoot, "A10C", "L10N", "Example.lua" );
-    //    Assert.NotNull( fileNode );
-    //    fileNode!.CheckState = true;
-
-    //    Assert.True( viewModel.CanApply );
-
-    //    await viewModel.Apply();
-
-    //    var destinationPath = Path.Combine(
-    //        sourceRoot,
-    //        "A10C",
-    //        "L10N",
-    //        "Example.lua"
-    //    );
-    //    Assert.True( File.Exists( destinationPath ) );
-    //    Assert.Equal( fileContent, File.ReadAllText( destinationPath, Encoding.UTF8 ) );
-
-    //    var translationPath = Path.Combine(
-    //        _tempDir,
-    //        "DCSWorld",
-    //        "Mods",
-    //        "aircraft",
-    //        "A10C",
-    //        "L10N",
-    //        "Example.lua"
-    //    );
-    //    Assert.True( File.Exists( translationPath ) );
-
-    //    Assert.Contains( snackbarMessages, message => message == "適用完了 成功:1 件 失敗:0 件" );
-    //    Assert.Equal( 100, viewModel.AppliedProgress );
-    //    Assert.True( viewModel.CanApply );
-
-    //    apiServiceMock.VerifyAll();
-    //    zipServiceMock.VerifyAll();
-    //}
-
-    ///// <summary>Applyを呼び出すとUserMissions配下の miz を適用する。</summary>
-    //[StaFact]
-    //public async Task Applyを呼び出すとUserMissions配下のmizを適用する() {
-    //    var sourceRoot = Path.Combine( _tempDir, "UserMissionSource" );
-    //    var mizDirectory = Path.Combine( sourceRoot, "MyMissions" );
-    //    Directory.CreateDirectory( mizDirectory );
-    //    var mizPath = Path.Combine( mizDirectory, "SampleMission.miz" );
-    //    File.WriteAllBytes( mizPath, [] );
-
-    //    var appSettings = new AppSettings
-    //    {
-    //        TranslateFileDir = _tempDir,
-    //        SourceUserMissionDir = sourceRoot
-    //    };
-    //    const string repoEntryPath = "UserMissions/MyMissions/SampleMission.miz/Localization/Example.lua";
-    //    const string fileContent = "ユーザーミッション miz に適用する";
-
-    //    var repoEntry = new RepoFileEntry( "Example.lua", repoEntryPath, false, repoSha: "userfeed" );
-    //    var treeResult = Result.Ok<IReadOnlyList<FileEntry>>( [repoEntry] );
-
-    //    byte[] archiveBytes = CreateZipForApply(
-    //        (repoEntryPath, fileContent)
-    //    );
-    //    var downloadResult = Result.Ok(
-    //        new ApiDownloadFilesResult(
-    //            [repoEntryPath],
-    //            archiveBytes,
-    //            archiveBytes.Length,
-    //            "application/zip",
-    //            "apply-user-missions.zip",
-    //            "\"user-missions-etag\"",
-    //            false
-    //        )
-    //    );
-
-    //    var apiServiceMock = new Mock<IApiService>( MockBehavior.Strict );
-    //    apiServiceMock
-    //        .Setup( service => service.GetTreeAsync( It.IsAny<CancellationToken>() ) )
-    //        .ReturnsAsync( treeResult );
-    //    apiServiceMock
-    //        .Setup( service => service.DownloadFilesAsync(
-    //            It.Is<ApiDownloadFilesRequest>( request =>
-    //                request.Paths.Count == 1 &&
-    //                request.Paths[0] == repoEntryPath &&
-    //                request.ETag == null
-    //            ),
-    //            It.IsAny<CancellationToken>()
-    //        ) )
-    //        .ReturnsAsync( downloadResult );
-
-    //    var dispatcherServiceMock = new Mock<IDispatcherService>();
-    //    dispatcherServiceMock
-    //        .Setup( service => service.InvokeAsync( It.IsAny<Func<Task>>() ) )
-    //        .Returns<Func<Task>>( func => func() );
-
-    //    var appSettingsServiceMock = new Mock<IAppSettingsService>();
-    //    appSettingsServiceMock
-    //        .SetupGet( service => service.Settings )
-    //        .Returns( appSettings );
-
-    //    var fileEntryServiceMock = new Mock<IFileEntryService>();
-    //    var loggingServiceMock = new Mock<ILoggingService>();
-    //    var snackbarMessages = new List<string>();
-    //    var snackbarMessageQueueMock = new Mock<ISnackbarMessageQueue>();
-    //    var snackbarServiceMock = new Mock<ISnackbarService>();
-    //    snackbarServiceMock
-    //        .SetupGet( service => service.MessageQueue )
-    //        .Returns( snackbarMessageQueueMock.Object );
-    //    snackbarServiceMock
-    //        .Setup( service => service.Show(
-    //            It.IsAny<string>(),
-    //            It.IsAny<string?>(),
-    //            It.IsAny<Action?>(),
-    //            It.IsAny<object?>(),
-    //            It.IsAny<TimeSpan?>()
-    //        ) )
-    //        .Callback<string, string?, Action?, object?, TimeSpan?>(
-    //            ( message, _, _, _, _ ) => snackbarMessages.Add( message )
-    //        );
-
-    //    var systemServiceMock = new Mock<ISystemService>( MockBehavior.Strict );
-
-    //    var expectedTranslationPath = Path.Combine(
-    //        _tempDir,
-    //        "UserMissions",
-    //        "MyMissions",
-    //        "SampleMission.miz",
-    //        "Localization",
-    //        "Example.lua"
-    //    );
-    //    var zipServiceMock = new Mock<IZipService>( MockBehavior.Strict );
-    //    zipServiceMock
-    //        .Setup( service => service.AddEntry(
-    //            It.Is<string>( value => string.Equals( value, mizPath, StringComparison.OrdinalIgnoreCase ) ),
-    //            "Localization/Example.lua",
-    //            It.Is<string>( value => string.Equals( value, expectedTranslationPath, StringComparison.OrdinalIgnoreCase ) )
-    //        ) )
-    //        .Returns( Result.Ok );
-
-    //    var viewModel = new DownloadViewModel(
-    //        apiServiceMock.Object,
-    //        appSettingsServiceMock.Object,
-    //        dispatcherServiceMock.Object,
-    //        fileEntryServiceMock.Object,
-    //        loggingServiceMock.Object,
-    //        snackbarServiceMock.Object,
-    //        systemServiceMock.Object,
-    //        zipServiceMock.Object
-    //    );
-
-    //    await viewModel.Fetch();
-    //    var userMissionIndex = viewModel.Tabs
-    //        .Select( ( tab, index ) => ( tab, index ) )
-    //        .First( pair => pair.tab.TabType == CategoryType.UserMissions )
-    //        .index;
-    //    viewModel.SelectedTabIndex = userMissionIndex;
-
-    //    var userMissionRoot = viewModel.Tabs[userMissionIndex].Root;
-    //    var fileNode = FindNodeByPath( userMissionRoot, "MyMissions", "SampleMission.miz", "Localization", "Example.lua" );
-    //    Assert.NotNull( fileNode );
-    //    fileNode!.CheckState = true;
-
-    //    Assert.True( viewModel.CanApply );
-
-    //    await viewModel.Apply();
-
-    //    Assert.True( File.Exists( expectedTranslationPath ) );
-    //    Assert.Equal( fileContent, File.ReadAllText( expectedTranslationPath, Encoding.UTF8 ) );
-    //    zipServiceMock.VerifyAll();
-    //    Assert.Contains( snackbarMessages, message => message == "適用完了 成功:1 件 失敗:0 件" );
-    //    Assert.Equal( 100, viewModel.AppliedProgress );
-    //    Assert.True( viewModel.CanApply );
-
-    //    apiServiceMock.VerifyAll();
-    //}
-
-    ///// <summary>Applyを呼び出すと一部の miz 適用に失敗した場合は失敗件数を通知する。</summary>
-    //[StaFact]
-    //public async Task Applyを呼び出すと一部のmiz適用に失敗すると失敗件数を通知する() {
-    //    var sourceRoot = Path.Combine( _tempDir, "AircraftSourcePartial" );
-    //    var successMizDirectory = Path.Combine( sourceRoot, "A10C", "Missions", "EN" );
-    //    Directory.CreateDirectory( successMizDirectory );
-    //    var successMizPath = Path.Combine( successMizDirectory, "Success.miz" );
-    //    File.WriteAllBytes( successMizPath, [] );
-
-    //    var appSettings = new AppSettings
-    //    {
-    //        TranslateFileDir = _tempDir,
-    //        SourceAircraftDir = sourceRoot
-    //    };
-    //    const string successPath = "DCSWorld/Mods/aircraft/A10C/Missions/EN/Success.miz/Localization/Success.lua";
-    //    const string missingMizPath = "DCSWorld/Mods/aircraft/A10C/Missions/EN/Missing.miz/Localization/Missing.lua";
-
-    //    var repoEntries = new List<FileEntry> {
-    //        new RepoFileEntry( "Success.lua", successPath, false, repoSha: "deadbeef" ),
-    //        new RepoFileEntry( "Missing.lua", missingMizPath, false, repoSha: "badd00d" )
-    //    };
-    //    var treeResult = Result.Ok<IReadOnlyList<FileEntry>>( repoEntries );
-
-    //    byte[] archiveBytes = CreateZipForApply(
-    //        (successPath, "成功データ"),
-    //        (missingMizPath, "失敗データ")
-    //    );
-    //    var downloadResult = Result.Ok(
-    //        new ApiDownloadFilesResult(
-    //            [successPath, missingMizPath],
-    //            archiveBytes,
-    //            archiveBytes.Length,
-    //            "application/zip",
-    //            "apply-partial.zip",
-    //            "\"partial-etag\"",
-    //            false
-    //        )
-    //    );
-
-    //    var apiServiceMock = new Mock<IApiService>( MockBehavior.Strict );
-    //    apiServiceMock
-    //        .Setup( service => service.GetTreeAsync( It.IsAny<CancellationToken>() ) )
-    //        .ReturnsAsync( treeResult );
-    //    apiServiceMock
-    //        .Setup( service => service.DownloadFilesAsync(
-    //            It.Is<ApiDownloadFilesRequest>( request =>
-    //                request.Paths.Count == 2 &&
-    //                request.Paths.Contains( successPath ) &&
-    //                request.Paths.Contains( missingMizPath ) &&
-    //                request.ETag == null
-    //            ),
-    //            It.IsAny<CancellationToken>()
-    //        ) )
-    //        .ReturnsAsync( downloadResult );
-
-    //    var dispatcherServiceMock = new Mock<IDispatcherService>();
-    //    dispatcherServiceMock
-    //        .Setup( service => service.InvokeAsync( It.IsAny<Func<Task>>() ) )
-    //        .Returns<Func<Task>>( func => func() );
-
-    //    var appSettingsServiceMock = new Mock<IAppSettingsService>();
-    //    appSettingsServiceMock
-    //        .SetupGet( service => service.Settings )
-    //        .Returns( appSettings );
-
-    //    var fileEntryServiceMock = new Mock<IFileEntryService>();
-    //    var loggingServiceMock = new Mock<ILoggingService>();
-    //    var snackbarMessages = new List<string>();
-    //    var snackbarMessageQueueMock = new Mock<ISnackbarMessageQueue>();
-    //    var snackbarServiceMock = new Mock<ISnackbarService>();
-    //    snackbarServiceMock
-    //        .SetupGet( service => service.MessageQueue )
-    //        .Returns( snackbarMessageQueueMock.Object );
-    //    snackbarServiceMock
-    //        .Setup( service => service.Show(
-    //            It.IsAny<string>(),
-    //            It.IsAny<string?>(),
-    //            It.IsAny<Action?>(),
-    //            It.IsAny<object?>(),
-    //            It.IsAny<TimeSpan?>()
-    //        ) )
-    //        .Callback<string, string?, Action?, object?, TimeSpan?>(
-    //            ( message, _, _, _, _ ) => snackbarMessages.Add( message )
-    //        );
-
-    //    var systemServiceMock = new Mock<ISystemService>( MockBehavior.Strict );
-
-    //    var zipServiceMock = new Mock<IZipService>( MockBehavior.Strict );
-    //    zipServiceMock
-    //        .Setup( service => service.AddEntry(
-    //            It.Is<string>( value => string.Equals( value, successMizPath, StringComparison.OrdinalIgnoreCase ) ),
-    //            "Localization/Success.lua",
-    //            It.Is<string>( value => string.Equals(
-    //                value,
-    //                Path.Combine(
-    //                    _tempDir,
-    //                    "DCSWorld",
-    //                    "Mods",
-    //                    "aircraft",
-    //                    "A10C",
-    //                    "Missions",
-    //                    "EN",
-    //                    "Success.miz",
-    //                    "Localization",
-    //                    "Success.lua"
-    //                ),
-    //                StringComparison.OrdinalIgnoreCase ) )
-    //        ) )
-    //        .Returns( Result.Ok );
-
-    //    var viewModel = new DownloadViewModel(
-    //        apiServiceMock.Object,
-    //        appSettingsServiceMock.Object,
-    //        dispatcherServiceMock.Object,
-    //        fileEntryServiceMock.Object,
-    //        loggingServiceMock.Object,
-    //        snackbarServiceMock.Object,
-    //        systemServiceMock.Object,
-    //        zipServiceMock.Object
-    //    );
-
-    //    await viewModel.Fetch();
-    //    var aircraftIndex = viewModel.Tabs
-    //        .Select( ( tab, index ) => ( tab, index ) )
-    //        .First( pair => pair.tab.TabType == CategoryType.Aircraft )
-    //        .index;
-    //    viewModel.SelectedTabIndex = aircraftIndex;
-
-    //    var aircraftRoot = viewModel.Tabs[aircraftIndex].Root;
-    //    var successNode = FindNodeByPath( aircraftRoot, "A10C", "Missions", "EN", "Success.miz", "Localization", "Success.lua" );
-    //    var missingNode = FindNodeByPath( aircraftRoot, "A10C", "Missions", "EN", "Missing.miz", "Localization", "Missing.lua" );
-    //    Assert.NotNull( successNode );
-    //    Assert.NotNull( missingNode );
-    //    successNode!.CheckState = true;
-    //    missingNode!.CheckState = true;
-
-    //    Assert.True( viewModel.CanApply );
-
-    //    await viewModel.Apply();
-
-    //    var expectedSuccessTranslationPath = Path.Combine(
-    //        _tempDir,
-    //        "DCSWorld",
-    //        "Mods",
-    //        "aircraft",
-    //        "A10C",
-    //        "Missions",
-    //        "EN",
-    //        "Success.miz",
-    //        "Localization",
-    //        "Success.lua"
-    //    );
-    //    Assert.True( File.Exists( expectedSuccessTranslationPath ) );
-
-    //    var expectedMissingTranslationPath = Path.Combine(
-    //        _tempDir,
-    //        "DCSWorld",
-    //        "Mods",
-    //        "aircraft",
-    //        "A10C",
-    //        "Missions",
-    //        "EN",
-    //        "Missing.miz",
-    //        "Localization",
-    //        "Missing.lua"
-    //    );
-    //    Assert.True( File.Exists( expectedMissingTranslationPath ) );
-
-    //    zipServiceMock.Verify( service => service.AddEntry(
-    //        It.Is<string>( value => string.Equals( value, successMizPath, StringComparison.OrdinalIgnoreCase ) ),
-    //        "Localization/Success.lua",
-    //        It.IsAny<string>()
-    //    ), Times.Once );
-    //    zipServiceMock.VerifyNoOtherCalls();
-
-    //    Assert.Contains( snackbarMessages, message => message == $"圧縮ファイルが存在しません: {missingMizPath}" );
-    //    Assert.Contains( snackbarMessages, message => message == "適用完了 成功:1 件 失敗:1 件" );
-    //    Assert.Equal( 100, viewModel.AppliedProgress );
-    //    Assert.True( viewModel.CanApply );
-
-    //    apiServiceMock.VerifyAll();
-    //}
-
-    ///// <summary>Applyを呼び出すとリポジトリ取得に失敗した場合は処理を中断する。</summary>
-    //[StaFact]
-    //public async Task Applyを呼び出すとリポジトリ取得に失敗すると処理を中断する() {
-    //    var sourceRoot = Path.Combine( _tempDir, "AircraftSourceFailure" );
-    //    Directory.CreateDirectory( sourceRoot );
-
-    //    var appSettings = new AppSettings
-    //    {
-    //        TranslateFileDir = _tempDir,
-    //        SourceAircraftDir = sourceRoot
-    //    };
-    //    const string repoEntryPath = "DCSWorld/Mods/aircraft/A10C/Missions/EN/Failure.miz/Localization/Failure.lua";
-
-    //    var repoEntry = new RepoFileEntry( "Failure.lua", repoEntryPath, false, repoSha: "facefeed" );
-    //    var treeResult = Result.Ok<IReadOnlyList<FileEntry>>( [repoEntry] );
-
-    //    var apiServiceMock = new Mock<IApiService>( MockBehavior.Strict );
-    //    apiServiceMock
-    //        .Setup( service => service.GetTreeAsync( It.IsAny<CancellationToken>() ) )
-    //        .ReturnsAsync( treeResult );
-    //    apiServiceMock
-    //        .Setup( service => service.DownloadFilesAsync(
-    //            It.Is<ApiDownloadFilesRequest>( request =>
-    //                request.Paths.Count == 1 &&
-    //                request.Paths[0] == repoEntryPath &&
-    //                request.ETag == null
-    //            ),
-    //            It.IsAny<CancellationToken>()
-    //        ) )
-    //        .ReturnsAsync( Result.Fail<ApiDownloadFilesResult>( "network failure" ) );
-
-    //    var dispatcherServiceMock = new Mock<IDispatcherService>();
-    //    dispatcherServiceMock
-    //        .Setup( service => service.InvokeAsync( It.IsAny<Func<Task>>() ) )
-    //        .Returns<Func<Task>>( func => func() );
-
-    //    var appSettingsServiceMock = new Mock<IAppSettingsService>();
-    //    appSettingsServiceMock
-    //        .SetupGet( service => service.Settings )
-    //        .Returns( appSettings );
-
-    //    var fileEntryServiceMock = new Mock<IFileEntryService>();
-    //    var loggingServiceMock = new Mock<ILoggingService>();
-    //    var snackbarMessages = new List<string>();
-    //    var snackbarMessageQueueMock = new Mock<ISnackbarMessageQueue>();
-    //    var snackbarServiceMock = new Mock<ISnackbarService>();
-    //    snackbarServiceMock
-    //        .SetupGet( service => service.MessageQueue )
-    //        .Returns( snackbarMessageQueueMock.Object );
-    //    snackbarServiceMock
-    //        .Setup( service => service.Show(
-    //            It.IsAny<string>(),
-    //            It.IsAny<string?>(),
-    //            It.IsAny<Action?>(),
-    //            It.IsAny<object?>(),
-    //            It.IsAny<TimeSpan?>()
-    //        ) )
-    //        .Callback<string, string?, Action?, object?, TimeSpan?>(
-    //            ( message, _, _, _, _ ) => snackbarMessages.Add( message )
-    //        );
-
-    //    var systemServiceMock = new Mock<ISystemService>( MockBehavior.Strict );
-    //    var zipServiceMock = new Mock<IZipService>( MockBehavior.Strict );
-
-    //    var viewModel = new DownloadViewModel(
-    //        apiServiceMock.Object,
-    //        appSettingsServiceMock.Object,
-    //        dispatcherServiceMock.Object,
-    //        fileEntryServiceMock.Object,
-    //        loggingServiceMock.Object,
-    //        snackbarServiceMock.Object,
-    //        systemServiceMock.Object,
-    //        zipServiceMock.Object
-    //    );
-
-    //    await viewModel.Fetch();
-    //    var aircraftIndex = viewModel.Tabs
-    //        .Select( ( tab, index ) => ( tab, index ) )
-    //        .First( pair => pair.tab.TabType == CategoryType.Aircraft )
-    //        .index;
-    //    viewModel.SelectedTabIndex = aircraftIndex;
-
-    //    var aircraftRoot = viewModel.Tabs[aircraftIndex].Root;
-    //    var fileNode = FindNodeByPath( aircraftRoot, "A10C", "Missions", "EN", "Failure.miz", "Localization", "Failure.lua" );
-    //    Assert.NotNull( fileNode );
-    //    fileNode!.CheckState = true;
-
-    //    Assert.True( viewModel.CanApply );
-
-    //    await viewModel.Apply();
-
-    //    zipServiceMock.VerifyNoOtherCalls();
-    //    Assert.DoesNotContain( snackbarMessages, message => message.StartsWith( "適用完了", StringComparison.Ordinal ) );
-    //    Assert.Contains( snackbarMessages, message => message == "リポジトリからの取得に失敗しました" );
-    //    Assert.Equal( 0, viewModel.AppliedProgress );
-    //    Assert.True( viewModel.CanApply );
-
-    //    apiServiceMock.VerifyAll();
-    //}
+    /// <summary>Applyを呼び出すとModifiedエントリで全てローカル版適用を実行することを確認する。</summary>
+    [StaFact]
+    public async Task Applyを呼び出すとModifiedエントリで全てローカル版適用を実行する() {
+        var appSettings = new AppSettings
+        {
+            TranslateFileDir = _tempDir,
+            DcsWorldInstallDir = Path.Combine( _tempDir, "DcsWorld" )
+        };
+        const string repoEntryPath = "DCSWorld/Mods/aircraft/A10C/L10N/Example.lua";
+        var repoEntry = new RepoFileEntry( "Example.lua", repoEntryPath, false, repoSha: "repo-sha" );
+        var localEntry = new LocalFileEntry( "Example.lua", repoEntryPath, false, "local-sha" );
+        var treeResult = Result.Ok<IReadOnlyList<FileEntry>>( [repoEntry] );
+
+        var apiServiceMock = new Mock<IApiService>( MockBehavior.Strict );
+        apiServiceMock
+            .Setup( service => service.GetTreeAsync( It.IsAny<CancellationToken>() ) )
+            .ReturnsAsync( treeResult );
+
+        var dispatcherServiceMock = new Mock<IDispatcherService>();
+        dispatcherServiceMock
+            .Setup( service => service.InvokeAsync( It.IsAny<Func<Task>>() ) )
+            .Returns<Func<Task>>( func => func() );
+
+        var appSettingsServiceMock = new Mock<IAppSettingsService>();
+        appSettingsServiceMock
+            .SetupGet( service => service.Settings )
+            .Returns( appSettings );
+
+        var fileEntryServiceMock = new Mock<IFileEntryService>( MockBehavior.Strict );
+        fileEntryServiceMock
+            .Setup( service => service.GetEntriesAsync() )
+            .ReturnsAsync( Result.Ok<IReadOnlyList<FileEntry>>( [localEntry] ) );
+
+        var loggingServiceMock = new Mock<ILoggingService>();
+        var snackbarMessageQueueMock = new Mock<ISnackbarMessageQueue>();
+        var snackbarServiceMock = new Mock<ISnackbarService>();
+        snackbarServiceMock
+            .SetupGet( service => service.MessageQueue )
+            .Returns( snackbarMessageQueueMock.Object );
+        snackbarServiceMock
+            .Setup( service => service.Show(
+                It.IsAny<string>(),
+                It.IsAny<string?>(),
+                It.IsAny<Action?>(),
+                It.IsAny<object?>(),
+                It.IsAny<TimeSpan?>()
+            ) );
+
+        var systemServiceMock = new Mock<ISystemService>( MockBehavior.Strict );
+        var downloadWorkflowServiceMock = new Mock<IDownloadWorkflowService>( MockBehavior.Strict );
+        var fileEntryWatcherLifecycleMock = new Mock<IFileEntryWatcherLifecycle>( MockBehavior.Strict );
+        var fileEntryTreeService = new FileEntryTreeService( loggingServiceMock.Object );
+        var dialogServiceMock = new Mock<IDialogService>( MockBehavior.Strict );
+
+        dialogServiceMock
+            .Setup( service => service.DownloadModifiedApplyModeDialogShowAsync(
+                It.Is<DownloadModifiedApplyModeDialogParameters>( parameters =>
+                    parameters.ApplyAllRepositoryButtonText == "全てサーバー版を適用" &&
+                    parameters.ApplyAllLocalButtonText == "全てローカル版を適用" &&
+                    parameters.SelectIndividuallyButtonText == "個別に選択する" &&
+                    parameters.CancelButtonText == "中止" ) ) )
+            .ReturnsAsync( DownloadModifiedApplyModeDialogResult.ApplyAllLocal );
+
+        downloadWorkflowServiceMock
+            .Setup( service => service.ExecuteApplyAsync(
+                It.IsAny<ApplyExecutionRequest>(),
+                It.IsAny<Func<string, Task>>(),
+                It.IsAny<Func<double, Task>>(),
+                It.IsAny<CancellationToken>()
+            ) )
+            .ReturnsAsync( new ApplyWorkflowResult( true, [] ) );
+
+        var viewModel = new DownloadViewModel(
+            apiServiceMock.Object,
+            appSettingsServiceMock.Object,
+            dialogServiceMock.Object,
+            downloadWorkflowServiceMock.Object,
+            dispatcherServiceMock.Object,
+            fileEntryServiceMock.Object,
+            fileEntryWatcherLifecycleMock.Object,
+            fileEntryTreeService,
+            loggingServiceMock.Object,
+            snackbarServiceMock.Object,
+            systemServiceMock.Object
+        );
+
+        await viewModel.Fetch();
+        var aircraftIndex = viewModel.Tabs
+            .Select( ( tab, index ) => ( tab, index ) )
+            .First( pair => pair.tab.TabType == CategoryType.Aircraft )
+            .index;
+        viewModel.SelectedTabIndex = aircraftIndex;
+
+        var fileNode = FindNodeByPath( viewModel.Tabs[aircraftIndex].Root, "A10C", "L10N", "Example.lua" );
+        Assert.NotNull( fileNode );
+        Assert.Equal( FileChangeType.Modified, fileNode!.ChangeType );
+        fileNode.CheckState = true;
+
+        await viewModel.Apply();
+
+        dialogServiceMock.VerifyAll();
+        downloadWorkflowServiceMock.Verify( service => service.SyncModifiedFilesWithRepositoryAsync(
+            It.IsAny<IReadOnlyList<IFileEntryViewModel>>(),
+            It.IsAny<string>(),
+            It.IsAny<Func<string, Task>>(),
+            It.IsAny<CancellationToken>()
+        ), Times.Never );
+        downloadWorkflowServiceMock.Verify( service => service.ExecuteApplyAsync(
+            It.IsAny<ApplyExecutionRequest>(),
+            It.IsAny<Func<string, Task>>(),
+            It.IsAny<Func<double, Task>>(),
+            It.IsAny<CancellationToken>()
+        ), Times.Once );
+    }
+
+    /// <summary>Applyを呼び出すとModifiedエントリで全てサーバー版適用を実行することを確認する。</summary>
+    [StaFact]
+    public async Task Applyを呼び出すとModifiedエントリで全てサーバー版適用を実行する() {
+        var appSettings = new AppSettings
+        {
+            TranslateFileDir = _tempDir,
+            DcsWorldInstallDir = Path.Combine( _tempDir, "DcsWorld" )
+        };
+        const string repoEntryPath = "DCSWorld/Mods/aircraft/A10C/L10N/Example.lua";
+        var repoEntry = new RepoFileEntry( "Example.lua", repoEntryPath, false, repoSha: "repo-sha" );
+        var localEntry = new LocalFileEntry( "Example.lua", repoEntryPath, false, "local-sha" );
+        var treeResult = Result.Ok<IReadOnlyList<FileEntry>>( [repoEntry] );
+
+        var apiServiceMock = new Mock<IApiService>( MockBehavior.Strict );
+        apiServiceMock
+            .Setup( service => service.GetTreeAsync( It.IsAny<CancellationToken>() ) )
+            .ReturnsAsync( treeResult );
+
+        var dispatcherServiceMock = new Mock<IDispatcherService>();
+        dispatcherServiceMock
+            .Setup( service => service.InvokeAsync( It.IsAny<Func<Task>>() ) )
+            .Returns<Func<Task>>( func => func() );
+
+        var appSettingsServiceMock = new Mock<IAppSettingsService>();
+        appSettingsServiceMock
+            .SetupGet( service => service.Settings )
+            .Returns( appSettings );
+
+        var fileEntryServiceMock = new Mock<IFileEntryService>( MockBehavior.Strict );
+        fileEntryServiceMock
+            .Setup( service => service.GetEntriesAsync() )
+            .ReturnsAsync( Result.Ok<IReadOnlyList<FileEntry>>( [localEntry] ) );
+
+        var loggingServiceMock = new Mock<ILoggingService>();
+        var snackbarMessageQueueMock = new Mock<ISnackbarMessageQueue>();
+        var snackbarServiceMock = new Mock<ISnackbarService>();
+        snackbarServiceMock
+            .SetupGet( service => service.MessageQueue )
+            .Returns( snackbarMessageQueueMock.Object );
+        snackbarServiceMock
+            .Setup( service => service.Show(
+                It.IsAny<string>(),
+                It.IsAny<string?>(),
+                It.IsAny<Action?>(),
+                It.IsAny<object?>(),
+                It.IsAny<TimeSpan?>()
+            ) );
+
+        var systemServiceMock = new Mock<ISystemService>( MockBehavior.Strict );
+        var downloadWorkflowServiceMock = new Mock<IDownloadWorkflowService>( MockBehavior.Strict );
+        var fileEntryWatcherLifecycleMock = new Mock<IFileEntryWatcherLifecycle>( MockBehavior.Strict );
+        var fileEntryTreeService = new FileEntryTreeService( loggingServiceMock.Object );
+        var dialogServiceMock = new Mock<IDialogService>( MockBehavior.Strict );
+
+        dialogServiceMock
+            .Setup( service => service.DownloadModifiedApplyModeDialogShowAsync( It.IsAny<DownloadModifiedApplyModeDialogParameters>() ) )
+            .ReturnsAsync( DownloadModifiedApplyModeDialogResult.ApplyAllRepository );
+
+        downloadWorkflowServiceMock
+            .Setup( service => service.SyncModifiedFilesWithRepositoryAsync(
+                It.Is<IReadOnlyList<IFileEntryViewModel>>( entries => entries.Count == 1 && entries[0].Path == repoEntryPath ),
+                _tempDir,
+                It.IsAny<Func<string, Task>>(),
+                It.IsAny<CancellationToken>()
+            ) )
+            .ReturnsAsync( true );
+
+        downloadWorkflowServiceMock
+            .Setup( service => service.ExecuteApplyAsync(
+                It.IsAny<ApplyExecutionRequest>(),
+                It.IsAny<Func<string, Task>>(),
+                It.IsAny<Func<double, Task>>(),
+                It.IsAny<CancellationToken>()
+            ) )
+            .ReturnsAsync( new ApplyWorkflowResult( true, [] ) );
+
+        var viewModel = new DownloadViewModel(
+            apiServiceMock.Object,
+            appSettingsServiceMock.Object,
+            dialogServiceMock.Object,
+            downloadWorkflowServiceMock.Object,
+            dispatcherServiceMock.Object,
+            fileEntryServiceMock.Object,
+            fileEntryWatcherLifecycleMock.Object,
+            fileEntryTreeService,
+            loggingServiceMock.Object,
+            snackbarServiceMock.Object,
+            systemServiceMock.Object
+        );
+
+        await viewModel.Fetch();
+        var aircraftIndex = viewModel.Tabs
+            .Select( ( tab, index ) => ( tab, index ) )
+            .First( pair => pair.tab.TabType == CategoryType.Aircraft )
+            .index;
+        viewModel.SelectedTabIndex = aircraftIndex;
+
+        var fileNode = FindNodeByPath( viewModel.Tabs[aircraftIndex].Root, "A10C", "L10N", "Example.lua" );
+        Assert.NotNull( fileNode );
+        fileNode!.CheckState = true;
+
+        await viewModel.Apply();
+
+        downloadWorkflowServiceMock.VerifyAll();
+    }
+
+    /// <summary>Applyを呼び出すとModifiedエントリで個別選択後にサーバー版指定分のみ同期することを確認する。</summary>
+    [StaFact]
+    public async Task Applyを呼び出すとModifiedエントリで個別選択後にサーバー版指定分のみ同期する() {
+        var appSettings = new AppSettings
+        {
+            TranslateFileDir = _tempDir,
+            DcsWorldInstallDir = Path.Combine( _tempDir, "DcsWorld" )
+        };
+        const string repoEntryPath1 = "DCSWorld/Mods/aircraft/A10C/L10N/Example.lua";
+        const string repoEntryPath2 = "DCSWorld/Mods/aircraft/A10C/L10N/Alt.lua";
+        var repoEntries = new FileEntry[]
+        {
+            new RepoFileEntry( "Example.lua", repoEntryPath1, false, repoSha: "repo-sha-1" ),
+            new RepoFileEntry( "Alt.lua", repoEntryPath2, false, repoSha: "repo-sha-2" )
+        };
+        var localEntries = new FileEntry[]
+        {
+            new LocalFileEntry( "Example.lua", repoEntryPath1, false, "local-sha-1" ),
+            new LocalFileEntry( "Alt.lua", repoEntryPath2, false, "local-sha-2" )
+        };
+        var treeResult = Result.Ok<IReadOnlyList<FileEntry>>( repoEntries );
+
+        var apiServiceMock = new Mock<IApiService>( MockBehavior.Strict );
+        apiServiceMock
+            .Setup( service => service.GetTreeAsync( It.IsAny<CancellationToken>() ) )
+            .ReturnsAsync( treeResult );
+
+        var dispatcherServiceMock = new Mock<IDispatcherService>();
+        dispatcherServiceMock
+            .Setup( service => service.InvokeAsync( It.IsAny<Func<Task>>() ) )
+            .Returns<Func<Task>>( func => func() );
+
+        var appSettingsServiceMock = new Mock<IAppSettingsService>();
+        appSettingsServiceMock
+            .SetupGet( service => service.Settings )
+            .Returns( appSettings );
+
+        var fileEntryServiceMock = new Mock<IFileEntryService>( MockBehavior.Strict );
+        fileEntryServiceMock
+            .Setup( service => service.GetEntriesAsync() )
+            .ReturnsAsync( Result.Ok<IReadOnlyList<FileEntry>>( localEntries ) );
+
+        var loggingServiceMock = new Mock<ILoggingService>();
+        var snackbarMessageQueueMock = new Mock<ISnackbarMessageQueue>();
+        var snackbarServiceMock = new Mock<ISnackbarService>();
+        snackbarServiceMock
+            .SetupGet( service => service.MessageQueue )
+            .Returns( snackbarMessageQueueMock.Object );
+        snackbarServiceMock
+            .Setup( service => service.Show(
+                It.IsAny<string>(),
+                It.IsAny<string?>(),
+                It.IsAny<Action?>(),
+                It.IsAny<object?>(),
+                It.IsAny<TimeSpan?>()
+            ) );
+
+        var systemServiceMock = new Mock<ISystemService>( MockBehavior.Strict );
+        var downloadWorkflowServiceMock = new Mock<IDownloadWorkflowService>( MockBehavior.Strict );
+        var fileEntryWatcherLifecycleMock = new Mock<IFileEntryWatcherLifecycle>( MockBehavior.Strict );
+        var fileEntryTreeService = new FileEntryTreeService( loggingServiceMock.Object );
+        var dialogServiceMock = new Mock<IDialogService>( MockBehavior.Strict );
+
+        dialogServiceMock
+            .Setup( service => service.DownloadModifiedApplyModeDialogShowAsync( It.IsAny<DownloadModifiedApplyModeDialogParameters>() ) )
+            .ReturnsAsync( DownloadModifiedApplyModeDialogResult.SelectIndividually );
+
+        dialogServiceMock
+            .Setup( service => service.DownloadModifiedApplySelectionDialogShowAsync( It.IsAny<DownloadModifiedApplySelectionDialogParameters>() ) )
+            .ReturnsAsync( new DownloadModifiedApplySelectionDialogResult(
+                true,
+                new Dictionary<string, DownloadModifiedApplySource>
+                {
+                    [repoEntryPath1] = DownloadModifiedApplySource.Repository,
+                    [repoEntryPath2] = DownloadModifiedApplySource.Local
+                } ) );
+
+        downloadWorkflowServiceMock
+            .Setup( service => service.SyncModifiedFilesWithRepositoryAsync(
+                It.Is<IReadOnlyList<IFileEntryViewModel>>( entries => entries.Count == 1 && entries[0].Path == repoEntryPath1 ),
+                _tempDir,
+                It.IsAny<Func<string, Task>>(),
+                It.IsAny<CancellationToken>()
+            ) )
+            .ReturnsAsync( true );
+
+        downloadWorkflowServiceMock
+            .Setup( service => service.ExecuteApplyAsync(
+                It.IsAny<ApplyExecutionRequest>(),
+                It.IsAny<Func<string, Task>>(),
+                It.IsAny<Func<double, Task>>(),
+                It.IsAny<CancellationToken>()
+            ) )
+            .ReturnsAsync( new ApplyWorkflowResult( true, [] ) );
+
+        var viewModel = new DownloadViewModel(
+            apiServiceMock.Object,
+            appSettingsServiceMock.Object,
+            dialogServiceMock.Object,
+            downloadWorkflowServiceMock.Object,
+            dispatcherServiceMock.Object,
+            fileEntryServiceMock.Object,
+            fileEntryWatcherLifecycleMock.Object,
+            fileEntryTreeService,
+            loggingServiceMock.Object,
+            snackbarServiceMock.Object,
+            systemServiceMock.Object
+        );
+
+        await viewModel.Fetch();
+        var aircraftIndex = viewModel.Tabs
+            .Select( ( tab, index ) => ( tab, index ) )
+            .First( pair => pair.tab.TabType == CategoryType.Aircraft )
+            .index;
+        viewModel.SelectedTabIndex = aircraftIndex;
+
+        var fileNode1 = FindNodeByPath( viewModel.Tabs[aircraftIndex].Root, "A10C", "L10N", "Example.lua" );
+        var fileNode2 = FindNodeByPath( viewModel.Tabs[aircraftIndex].Root, "A10C", "L10N", "Alt.lua" );
+        Assert.NotNull( fileNode1 );
+        Assert.NotNull( fileNode2 );
+        fileNode1!.CheckState = true;
+        fileNode2!.CheckState = true;
+
+        await viewModel.Apply();
+
+        downloadWorkflowServiceMock.VerifyAll();
+    }
+
+    /// <summary>Applyを呼び出すとModifiedエントリでモード選択中止時は処理を実行しないことを確認する。</summary>
+    [StaFact]
+    public async Task Applyを呼び出すとModifiedエントリでモード選択中止時は処理を実行しない() {
+        var appSettings = new AppSettings
+        {
+            TranslateFileDir = _tempDir,
+            DcsWorldInstallDir = Path.Combine( _tempDir, "DcsWorld" )
+        };
+        const string repoEntryPath = "DCSWorld/Mods/aircraft/A10C/L10N/Example.lua";
+        var repoEntry = new RepoFileEntry( "Example.lua", repoEntryPath, false, repoSha: "repo-sha" );
+        var localEntry = new LocalFileEntry( "Example.lua", repoEntryPath, false, "local-sha" );
+        var treeResult = Result.Ok<IReadOnlyList<FileEntry>>( [repoEntry] );
+
+        var apiServiceMock = new Mock<IApiService>( MockBehavior.Strict );
+        apiServiceMock
+            .Setup( service => service.GetTreeAsync( It.IsAny<CancellationToken>() ) )
+            .ReturnsAsync( treeResult );
+
+        var dispatcherServiceMock = new Mock<IDispatcherService>();
+        dispatcherServiceMock
+            .Setup( service => service.InvokeAsync( It.IsAny<Func<Task>>() ) )
+            .Returns<Func<Task>>( func => func() );
+
+        var appSettingsServiceMock = new Mock<IAppSettingsService>();
+        appSettingsServiceMock
+            .SetupGet( service => service.Settings )
+            .Returns( appSettings );
+
+        var fileEntryServiceMock = new Mock<IFileEntryService>( MockBehavior.Strict );
+        fileEntryServiceMock
+            .Setup( service => service.GetEntriesAsync() )
+            .ReturnsAsync( Result.Ok<IReadOnlyList<FileEntry>>( [localEntry] ) );
+
+        var loggingServiceMock = new Mock<ILoggingService>();
+        var snackbarMessageQueueMock = new Mock<ISnackbarMessageQueue>();
+        var snackbarServiceMock = new Mock<ISnackbarService>();
+        snackbarServiceMock
+            .SetupGet( service => service.MessageQueue )
+            .Returns( snackbarMessageQueueMock.Object );
+        snackbarServiceMock
+            .Setup( service => service.Show(
+                It.IsAny<string>(),
+                It.IsAny<string?>(),
+                It.IsAny<Action?>(),
+                It.IsAny<object?>(),
+                It.IsAny<TimeSpan?>()
+            ) );
+
+        var systemServiceMock = new Mock<ISystemService>( MockBehavior.Strict );
+        var downloadWorkflowServiceMock = new Mock<IDownloadWorkflowService>( MockBehavior.Strict );
+        var fileEntryWatcherLifecycleMock = new Mock<IFileEntryWatcherLifecycle>( MockBehavior.Strict );
+        var fileEntryTreeService = new FileEntryTreeService( loggingServiceMock.Object );
+        var dialogServiceMock = new Mock<IDialogService>( MockBehavior.Strict );
+
+        dialogServiceMock
+            .Setup( service => service.DownloadModifiedApplyModeDialogShowAsync( It.IsAny<DownloadModifiedApplyModeDialogParameters>() ) )
+            .ReturnsAsync( DownloadModifiedApplyModeDialogResult.Cancel );
+
+        var viewModel = new DownloadViewModel(
+            apiServiceMock.Object,
+            appSettingsServiceMock.Object,
+            dialogServiceMock.Object,
+            downloadWorkflowServiceMock.Object,
+            dispatcherServiceMock.Object,
+            fileEntryServiceMock.Object,
+            fileEntryWatcherLifecycleMock.Object,
+            fileEntryTreeService,
+            loggingServiceMock.Object,
+            snackbarServiceMock.Object,
+            systemServiceMock.Object
+        );
+
+        await viewModel.Fetch();
+        var aircraftIndex = viewModel.Tabs
+            .Select( ( tab, index ) => ( tab, index ) )
+            .First( pair => pair.tab.TabType == CategoryType.Aircraft )
+            .index;
+        viewModel.SelectedTabIndex = aircraftIndex;
+
+        var fileNode = FindNodeByPath( viewModel.Tabs[aircraftIndex].Root, "A10C", "L10N", "Example.lua" );
+        Assert.NotNull( fileNode );
+        fileNode!.CheckState = true;
+
+        await viewModel.Apply();
+
+        downloadWorkflowServiceMock.Verify( service => service.SyncModifiedFilesWithRepositoryAsync(
+            It.IsAny<IReadOnlyList<IFileEntryViewModel>>(),
+            It.IsAny<string>(),
+            It.IsAny<Func<string, Task>>(),
+            It.IsAny<CancellationToken>()
+        ), Times.Never );
+        downloadWorkflowServiceMock.Verify( service => service.ExecuteApplyAsync(
+            It.IsAny<ApplyExecutionRequest>(),
+            It.IsAny<Func<string, Task>>(),
+            It.IsAny<Func<double, Task>>(),
+            It.IsAny<CancellationToken>()
+        ), Times.Never );
+    }
+
+    /// <summary>Applyを呼び出すとModifiedエントリで個別選択中止時は処理を実行しないことを確認する。</summary>
+    [StaFact]
+    public async Task Applyを呼び出すとModifiedエントリで個別選択中止時は処理を実行しない() {
+        var appSettings = new AppSettings
+        {
+            TranslateFileDir = _tempDir,
+            DcsWorldInstallDir = Path.Combine( _tempDir, "DcsWorld" )
+        };
+        const string repoEntryPath = "DCSWorld/Mods/aircraft/A10C/L10N/Example.lua";
+        var repoEntry = new RepoFileEntry( "Example.lua", repoEntryPath, false, repoSha: "repo-sha" );
+        var localEntry = new LocalFileEntry( "Example.lua", repoEntryPath, false, "local-sha" );
+        var treeResult = Result.Ok<IReadOnlyList<FileEntry>>( [repoEntry] );
+
+        var apiServiceMock = new Mock<IApiService>( MockBehavior.Strict );
+        apiServiceMock
+            .Setup( service => service.GetTreeAsync( It.IsAny<CancellationToken>() ) )
+            .ReturnsAsync( treeResult );
+
+        var dispatcherServiceMock = new Mock<IDispatcherService>();
+        dispatcherServiceMock
+            .Setup( service => service.InvokeAsync( It.IsAny<Func<Task>>() ) )
+            .Returns<Func<Task>>( func => func() );
+
+        var appSettingsServiceMock = new Mock<IAppSettingsService>();
+        appSettingsServiceMock
+            .SetupGet( service => service.Settings )
+            .Returns( appSettings );
+
+        var fileEntryServiceMock = new Mock<IFileEntryService>( MockBehavior.Strict );
+        fileEntryServiceMock
+            .Setup( service => service.GetEntriesAsync() )
+            .ReturnsAsync( Result.Ok<IReadOnlyList<FileEntry>>( [localEntry] ) );
+
+        var loggingServiceMock = new Mock<ILoggingService>();
+        var snackbarMessageQueueMock = new Mock<ISnackbarMessageQueue>();
+        var snackbarServiceMock = new Mock<ISnackbarService>();
+        snackbarServiceMock
+            .SetupGet( service => service.MessageQueue )
+            .Returns( snackbarMessageQueueMock.Object );
+        snackbarServiceMock
+            .Setup( service => service.Show(
+                It.IsAny<string>(),
+                It.IsAny<string?>(),
+                It.IsAny<Action?>(),
+                It.IsAny<object?>(),
+                It.IsAny<TimeSpan?>()
+            ) );
+
+        var systemServiceMock = new Mock<ISystemService>( MockBehavior.Strict );
+        var downloadWorkflowServiceMock = new Mock<IDownloadWorkflowService>( MockBehavior.Strict );
+        var fileEntryWatcherLifecycleMock = new Mock<IFileEntryWatcherLifecycle>( MockBehavior.Strict );
+        var fileEntryTreeService = new FileEntryTreeService( loggingServiceMock.Object );
+        var dialogServiceMock = new Mock<IDialogService>( MockBehavior.Strict );
+
+        dialogServiceMock
+            .Setup( service => service.DownloadModifiedApplyModeDialogShowAsync( It.IsAny<DownloadModifiedApplyModeDialogParameters>() ) )
+            .ReturnsAsync( DownloadModifiedApplyModeDialogResult.SelectIndividually );
+        dialogServiceMock
+            .Setup( service => service.DownloadModifiedApplySelectionDialogShowAsync( It.IsAny<DownloadModifiedApplySelectionDialogParameters>() ) )
+            .ReturnsAsync( new DownloadModifiedApplySelectionDialogResult( false, new Dictionary<string, DownloadModifiedApplySource>() ) );
+
+        var viewModel = new DownloadViewModel(
+            apiServiceMock.Object,
+            appSettingsServiceMock.Object,
+            dialogServiceMock.Object,
+            downloadWorkflowServiceMock.Object,
+            dispatcherServiceMock.Object,
+            fileEntryServiceMock.Object,
+            fileEntryWatcherLifecycleMock.Object,
+            fileEntryTreeService,
+            loggingServiceMock.Object,
+            snackbarServiceMock.Object,
+            systemServiceMock.Object
+        );
+
+        await viewModel.Fetch();
+        var aircraftIndex = viewModel.Tabs
+            .Select( ( tab, index ) => ( tab, index ) )
+            .First( pair => pair.tab.TabType == CategoryType.Aircraft )
+            .index;
+        viewModel.SelectedTabIndex = aircraftIndex;
+
+        var fileNode = FindNodeByPath( viewModel.Tabs[aircraftIndex].Root, "A10C", "L10N", "Example.lua" );
+        Assert.NotNull( fileNode );
+        fileNode!.CheckState = true;
+
+        await viewModel.Apply();
+
+        downloadWorkflowServiceMock.Verify( service => service.SyncModifiedFilesWithRepositoryAsync(
+            It.IsAny<IReadOnlyList<IFileEntryViewModel>>(),
+            It.IsAny<string>(),
+            It.IsAny<Func<string, Task>>(),
+            It.IsAny<CancellationToken>()
+        ), Times.Never );
+        downloadWorkflowServiceMock.Verify( service => service.ExecuteApplyAsync(
+            It.IsAny<ApplyExecutionRequest>(),
+            It.IsAny<Func<string, Task>>(),
+            It.IsAny<Func<double, Task>>(),
+            It.IsAny<CancellationToken>()
+        ), Times.Never );
+    }
+
 
     private static IFileEntryViewModel? FindNodeByPath( IFileEntryViewModel root, params string[] segments ) {
         IFileEntryViewModel? current = root;
@@ -1573,36 +1020,4 @@ public sealed class DownloadViewModelTests : IDisposable {
         return current;
     }
 
-    ///// <summary>適用テスト向けにシンプルなZIPアーカイブを作成する。</summary>
-    //private static byte[] CreateZipForApply( params (string Path, string Content)[] entries ) =>
-    //    CreateZipWithManifest( entries.Select( entry => new ManifestEntryTestData( entry.Path, entry.Content ) ).ToArray() );
-
-    //private sealed record ManifestEntryTestData( string Path, string Content, long? DeclaredSize = null, string? DeclaredHash = null );
-
-    //private static byte[] CreateZipWithManifest( params ManifestEntryTestData[] entries ) {
-    //    using var stream = new MemoryStream();
-    //    using(var archive = new ZipArchive( stream, ZipArchiveMode.Create, leaveOpen: true )) {
-    //        var manifestFiles = new List<object>();
-    //        foreach(var entryData in entries) {
-    //            var entry = archive.CreateEntry( entryData.Path );
-    //            using var entryStream = entry.Open();
-    //            var contentBytes = Encoding.UTF8.GetBytes( entryData.Content );
-    //            entryStream.Write( contentBytes, 0, contentBytes.Length );
-
-    //            var declaredSize = entryData.DeclaredSize ?? contentBytes.LongLength;
-    //            var declaredHash = entryData.DeclaredHash ?? Convert.ToHexString( SHA256.HashData( contentBytes ) );
-    //            manifestFiles.Add( new { path = entryData.Path, size = declaredSize, sha256 = declaredHash } );
-    //        }
-
-    //        var manifestEntry = archive.CreateEntry( "manifest.json" );
-    //        using var writer = new StreamWriter( manifestEntry.Open(), Encoding.UTF8 );
-    //        var manifest = new {
-    //            version = 1,
-    //            generatedAt = DateTimeOffset.UtcNow.ToString( "O" ),
-    //            files = manifestFiles
-    //        };
-    //        writer.Write( JsonSerializer.Serialize( manifest ) );
-    //    }
-    //    return stream.ToArray();
-    //}
 }

--- a/tests/DcsTranslationTool.Presentation.Wpf.UnitTests/Features/Download/DownloadViewModelTests.cs
+++ b/tests/DcsTranslationTool.Presentation.Wpf.UnitTests/Features/Download/DownloadViewModelTests.cs
@@ -356,6 +356,105 @@ public sealed class DownloadViewModelTests : IDisposable {
         apiServiceMock.VerifyAll();
     }
 
+    /// <summary>DownloadではLocalOnlyのみ選択時にボタンが無効になることを確認する。</summary>
+    [StaFact]
+    public async Task DownloadではLocalOnlyのみ選択時はCanDownloadがfalseになる() {
+        var appSettings = new AppSettings { TranslateFileDir = _tempDir };
+        const string localOnlyEntryPath = "DCSWorld/Mods/aircraft/A10C/L10N/LocalOnly.lua";
+        var treeResult = Result.Ok<IReadOnlyList<FileEntry>>( [] );
+        var localEntries = new FileEntry[]
+        {
+            new LocalFileEntry( "LocalOnly.lua", localOnlyEntryPath, false, "local-sha" )
+        };
+
+        var apiServiceMock = new Mock<IApiService>( MockBehavior.Strict );
+        apiServiceMock
+            .Setup( service => service.GetTreeAsync( It.IsAny<CancellationToken>() ) )
+            .ReturnsAsync( treeResult );
+
+        var dispatcherServiceMock = new Mock<IDispatcherService>();
+        dispatcherServiceMock
+            .Setup( service => service.InvokeAsync( It.IsAny<Func<Task>>() ) )
+            .Returns<Func<Task>>( func => func() );
+
+        var appSettingsServiceMock = new Mock<IAppSettingsService>();
+        appSettingsServiceMock
+            .SetupGet( service => service.Settings )
+            .Returns( appSettings );
+
+        var fileEntryServiceMock = new Mock<IFileEntryService>( MockBehavior.Strict );
+        fileEntryServiceMock
+            .Setup( service => service.GetEntriesAsync() )
+            .ReturnsAsync( Result.Ok<IReadOnlyList<FileEntry>>( localEntries ) );
+
+        var loggingServiceMock = new Mock<ILoggingService>();
+        var snackbarMessages = new List<string>();
+        var snackbarMessageQueueMock = new Mock<ISnackbarMessageQueue>();
+        var snackbarServiceMock = new Mock<ISnackbarService>();
+        snackbarServiceMock
+            .SetupGet( service => service.MessageQueue )
+            .Returns( snackbarMessageQueueMock.Object );
+        snackbarServiceMock
+            .Setup( service => service.Show(
+                It.IsAny<string>(),
+                It.IsAny<string?>(),
+                It.IsAny<Action?>(),
+                It.IsAny<object?>(),
+                It.IsAny<TimeSpan?>()
+            ) )
+            .Callback<string, string?, Action?, object?, TimeSpan?>(
+                ( message, _, _, _, _ ) => snackbarMessages.Add( message )
+            );
+
+        var systemServiceMock = new Mock<ISystemService>( MockBehavior.Strict );
+        var downloadWorkflowServiceMock = new Mock<IDownloadWorkflowService>( MockBehavior.Strict );
+        var fileEntryWatcherLifecycleMock = new Mock<IFileEntryWatcherLifecycle>( MockBehavior.Strict );
+        var fileEntryTreeService = new FileEntryTreeService( loggingServiceMock.Object );
+        var dialogServiceMock = new Mock<IDialogService>( MockBehavior.Strict );
+
+        var viewModel = new DownloadViewModel(
+            apiServiceMock.Object,
+            appSettingsServiceMock.Object,
+            dialogServiceMock.Object,
+            downloadWorkflowServiceMock.Object,
+            dispatcherServiceMock.Object,
+            fileEntryServiceMock.Object,
+            fileEntryWatcherLifecycleMock.Object,
+            fileEntryTreeService,
+            loggingServiceMock.Object,
+            snackbarServiceMock.Object,
+            systemServiceMock.Object
+        );
+
+        await viewModel.Fetch();
+        var aircraftIndex = viewModel.Tabs
+            .Select( ( tab, index ) => ( tab, index ) )
+            .First( pair => pair.tab.TabType == CategoryType.Aircraft )
+            .index;
+        viewModel.SelectedTabIndex = aircraftIndex;
+
+        var fileNode = await WaitForNodeAsync(
+            () => TryGetTabRoot( viewModel, aircraftIndex ),
+            "Aircraft タブに LocalOnly.lua が表示されない。",
+            "A10C",
+            "L10N",
+            "LocalOnly.lua"
+        );
+        Assert.NotNull( fileNode );
+        Assert.True( fileNode!.CanCheck );
+        fileNode.CheckState = true;
+
+        Assert.False( viewModel.CanDownload );
+        Assert.True( viewModel.CanApply );
+        var snackbarCount = snackbarMessages.Count;
+        downloadWorkflowServiceMock.Verify( service => service.ExecuteDownloadAsync(
+            It.IsAny<DownloadExecutionRequest>(),
+            It.IsAny<Func<double, Task>>(),
+            It.IsAny<CancellationToken>()
+        ), Times.Never );
+        Assert.Equal( snackbarCount, snackbarMessages.Count );
+    }
+
     /// <summary>Applyは適用ワークフローを実行することを確認する。</summary>
     [StaFact]
     public async Task Applyを呼び出すと適用ワークフローを実行する() {
@@ -553,7 +652,14 @@ public sealed class DownloadViewModelTests : IDisposable {
             .index;
         viewModel.SelectedTabIndex = aircraftIndex;
 
-        var fileNode = FindNodeByPath( viewModel.Tabs[aircraftIndex].Root, "A10C", "L10N", "Example.lua" );
+        var fileNode = await WaitForNodeWithChangeTypeAsync(
+            () => TryGetTabRoot( viewModel, aircraftIndex ),
+            FileChangeType.Modified,
+            "Example.lua が Modified として表示されない。",
+            "A10C",
+            "L10N",
+            "Example.lua"
+        );
         Assert.NotNull( fileNode );
         Assert.Equal( FileChangeType.Modified, fileNode!.ChangeType );
         fileNode.CheckState = true;
@@ -573,112 +679,6 @@ public sealed class DownloadViewModelTests : IDisposable {
             It.IsAny<Func<double, Task>>(),
             It.IsAny<CancellationToken>()
         ), Times.Once );
-    }
-
-    /// <summary>Applyを呼び出すとModifiedエントリで全てサーバー版適用を実行することを確認する。</summary>
-    [StaFact]
-    public async Task Applyを呼び出すとModifiedエントリで全てサーバー版適用を実行する() {
-        var appSettings = new AppSettings
-        {
-            TranslateFileDir = _tempDir,
-            DcsWorldInstallDir = Path.Combine( _tempDir, "DcsWorld" )
-        };
-        const string repoEntryPath = "DCSWorld/Mods/aircraft/A10C/L10N/Example.lua";
-        var repoEntry = new RepoFileEntry( "Example.lua", repoEntryPath, false, repoSha: "repo-sha" );
-        var localEntry = new LocalFileEntry( "Example.lua", repoEntryPath, false, "local-sha" );
-        var treeResult = Result.Ok<IReadOnlyList<FileEntry>>( [repoEntry] );
-
-        var apiServiceMock = new Mock<IApiService>( MockBehavior.Strict );
-        apiServiceMock
-            .Setup( service => service.GetTreeAsync( It.IsAny<CancellationToken>() ) )
-            .ReturnsAsync( treeResult );
-
-        var dispatcherServiceMock = new Mock<IDispatcherService>();
-        dispatcherServiceMock
-            .Setup( service => service.InvokeAsync( It.IsAny<Func<Task>>() ) )
-            .Returns<Func<Task>>( func => func() );
-
-        var appSettingsServiceMock = new Mock<IAppSettingsService>();
-        appSettingsServiceMock
-            .SetupGet( service => service.Settings )
-            .Returns( appSettings );
-
-        var fileEntryServiceMock = new Mock<IFileEntryService>( MockBehavior.Strict );
-        fileEntryServiceMock
-            .Setup( service => service.GetEntriesAsync() )
-            .ReturnsAsync( Result.Ok<IReadOnlyList<FileEntry>>( [localEntry] ) );
-
-        var loggingServiceMock = new Mock<ILoggingService>();
-        var snackbarMessageQueueMock = new Mock<ISnackbarMessageQueue>();
-        var snackbarServiceMock = new Mock<ISnackbarService>();
-        snackbarServiceMock
-            .SetupGet( service => service.MessageQueue )
-            .Returns( snackbarMessageQueueMock.Object );
-        snackbarServiceMock
-            .Setup( service => service.Show(
-                It.IsAny<string>(),
-                It.IsAny<string?>(),
-                It.IsAny<Action?>(),
-                It.IsAny<object?>(),
-                It.IsAny<TimeSpan?>()
-            ) );
-
-        var systemServiceMock = new Mock<ISystemService>( MockBehavior.Strict );
-        var downloadWorkflowServiceMock = new Mock<IDownloadWorkflowService>( MockBehavior.Strict );
-        var fileEntryWatcherLifecycleMock = new Mock<IFileEntryWatcherLifecycle>( MockBehavior.Strict );
-        var fileEntryTreeService = new FileEntryTreeService( loggingServiceMock.Object );
-        var dialogServiceMock = new Mock<IDialogService>( MockBehavior.Strict );
-
-        dialogServiceMock
-            .Setup( service => service.DownloadModifiedApplyModeDialogShowAsync( It.IsAny<DownloadModifiedApplyModeDialogParameters>() ) )
-            .ReturnsAsync( DownloadModifiedApplyModeDialogResult.ApplyAllRepository );
-
-        downloadWorkflowServiceMock
-            .Setup( service => service.SyncModifiedFilesWithRepositoryAsync(
-                It.Is<IReadOnlyList<IFileEntryViewModel>>( entries => entries.Count == 1 && entries[0].Path == repoEntryPath ),
-                _tempDir,
-                It.IsAny<Func<string, Task>>(),
-                It.IsAny<CancellationToken>()
-            ) )
-            .ReturnsAsync( true );
-
-        downloadWorkflowServiceMock
-            .Setup( service => service.ExecuteApplyAsync(
-                It.IsAny<ApplyExecutionRequest>(),
-                It.IsAny<Func<string, Task>>(),
-                It.IsAny<Func<double, Task>>(),
-                It.IsAny<CancellationToken>()
-            ) )
-            .ReturnsAsync( new ApplyWorkflowResult( true, [] ) );
-
-        var viewModel = new DownloadViewModel(
-            apiServiceMock.Object,
-            appSettingsServiceMock.Object,
-            dialogServiceMock.Object,
-            downloadWorkflowServiceMock.Object,
-            dispatcherServiceMock.Object,
-            fileEntryServiceMock.Object,
-            fileEntryWatcherLifecycleMock.Object,
-            fileEntryTreeService,
-            loggingServiceMock.Object,
-            snackbarServiceMock.Object,
-            systemServiceMock.Object
-        );
-
-        await viewModel.Fetch();
-        var aircraftIndex = viewModel.Tabs
-            .Select( ( tab, index ) => ( tab, index ) )
-            .First( pair => pair.tab.TabType == CategoryType.Aircraft )
-            .index;
-        viewModel.SelectedTabIndex = aircraftIndex;
-
-        var fileNode = FindNodeByPath( viewModel.Tabs[aircraftIndex].Root, "A10C", "L10N", "Example.lua" );
-        Assert.NotNull( fileNode );
-        fileNode!.CheckState = true;
-
-        await viewModel.Apply();
-
-        downloadWorkflowServiceMock.VerifyAll();
     }
 
     /// <summary>Applyを呼び出すとModifiedエントリで個別選択後にサーバー版指定分のみ同期することを確認する。</summary>
@@ -797,8 +797,22 @@ public sealed class DownloadViewModelTests : IDisposable {
             .index;
         viewModel.SelectedTabIndex = aircraftIndex;
 
-        var fileNode1 = FindNodeByPath( viewModel.Tabs[aircraftIndex].Root, "A10C", "L10N", "Example.lua" );
-        var fileNode2 = FindNodeByPath( viewModel.Tabs[aircraftIndex].Root, "A10C", "L10N", "Alt.lua" );
+        var fileNode1 = await WaitForNodeWithChangeTypeAsync(
+            () => TryGetTabRoot( viewModel, aircraftIndex ),
+            FileChangeType.Modified,
+            "Example.lua が Modified として表示されない。",
+            "A10C",
+            "L10N",
+            "Example.lua"
+        );
+        var fileNode2 = await WaitForNodeWithChangeTypeAsync(
+            () => TryGetTabRoot( viewModel, aircraftIndex ),
+            FileChangeType.Modified,
+            "Alt.lua が Modified として表示されない。",
+            "A10C",
+            "L10N",
+            "Alt.lua"
+        );
         Assert.NotNull( fileNode1 );
         Assert.NotNull( fileNode2 );
         fileNode1!.CheckState = true;
@@ -888,7 +902,14 @@ public sealed class DownloadViewModelTests : IDisposable {
             .index;
         viewModel.SelectedTabIndex = aircraftIndex;
 
-        var fileNode = FindNodeByPath( viewModel.Tabs[aircraftIndex].Root, "A10C", "L10N", "Example.lua" );
+        var fileNode = await WaitForNodeWithChangeTypeAsync(
+            () => TryGetTabRoot( viewModel, aircraftIndex ),
+            FileChangeType.Modified,
+            "Example.lua が Modified として表示されない。",
+            "A10C",
+            "L10N",
+            "Example.lua"
+        );
         Assert.NotNull( fileNode );
         fileNode!.CheckState = true;
 
@@ -990,7 +1011,14 @@ public sealed class DownloadViewModelTests : IDisposable {
             .index;
         viewModel.SelectedTabIndex = aircraftIndex;
 
-        var fileNode = FindNodeByPath( viewModel.Tabs[aircraftIndex].Root, "A10C", "L10N", "Example.lua" );
+        var fileNode = await WaitForNodeWithChangeTypeAsync(
+            () => TryGetTabRoot( viewModel, aircraftIndex ),
+            FileChangeType.Modified,
+            "Example.lua が Modified として表示されない。",
+            "A10C",
+            "L10N",
+            "Example.lua"
+        );
         Assert.NotNull( fileNode );
         fileNode!.CheckState = true;
 
@@ -1018,6 +1046,67 @@ public sealed class DownloadViewModelTests : IDisposable {
             if(current is null) return null;
         }
         return current;
+    }
+
+    /// <summary>指定インデックスのタブルートを取得する。</summary>
+    private static IFileEntryViewModel? TryGetTabRoot( DownloadViewModel viewModel, int tabIndex ) =>
+        tabIndex >= 0 && tabIndex < viewModel.Tabs.Count
+            ? viewModel.Tabs[tabIndex].Root
+            : null;
+
+    /// <summary>指定条件が満たされるまで待機する。</summary>
+    private static async Task WaitUntilAsync( Func<bool> predicate, string timeoutMessage, int timeoutMs = 3000 ) {
+        var startedAt = DateTime.UtcNow;
+        while((DateTime.UtcNow - startedAt).TotalMilliseconds < timeoutMs) {
+            if(predicate()) {
+                return;
+            }
+
+            await Task.Delay( 20 );
+        }
+
+        throw new TimeoutException( timeoutMessage );
+    }
+
+    /// <summary>指定パスのノードが表示されるまで待機して返す。</summary>
+    private static async Task<IFileEntryViewModel?> WaitForNodeAsync(
+        Func<IFileEntryViewModel?> rootAccessor,
+        string timeoutMessage,
+        params string[] segments
+    ) {
+        IFileEntryViewModel? node = null;
+        await WaitUntilAsync( () => {
+            var root = rootAccessor();
+            if(root is null) {
+                node = null;
+                return false;
+            }
+
+            node = FindNodeByPath( root, segments );
+            return node is not null;
+        }, timeoutMessage );
+        return node;
+    }
+
+    /// <summary>指定パスのノードが期待する変更種別になるまで待機して返す。</summary>
+    private static async Task<IFileEntryViewModel?> WaitForNodeWithChangeTypeAsync(
+        Func<IFileEntryViewModel?> rootAccessor,
+        FileChangeType expectedChangeType,
+        string timeoutMessage,
+        params string[] segments
+    ) {
+        IFileEntryViewModel? node = null;
+        await WaitUntilAsync( () => {
+            var root = rootAccessor();
+            if(root is null) {
+                node = null;
+                return false;
+            }
+
+            node = FindNodeByPath( root, segments );
+            return node?.ChangeType == expectedChangeType;
+        }, timeoutMessage );
+        return node;
     }
 
 }

--- a/tests/DcsTranslationTool.Presentation.Wpf.UnitTests/Services/DownloadWorkflowServiceTests.cs
+++ b/tests/DcsTranslationTool.Presentation.Wpf.UnitTests/Services/DownloadWorkflowServiceTests.cs
@@ -1,3 +1,6 @@
+using System.Net;
+using System.Text;
+
 using DcsTranslationTool.Application.Contracts;
 using DcsTranslationTool.Application.Interfaces;
 using DcsTranslationTool.Presentation.Wpf.Services;
@@ -285,6 +288,114 @@ public sealed class DownloadWorkflowServiceTests : IDisposable {
     }
 
     /// <summary>
+    /// Modified 対象のみをサーバー版で翻訳ディレクトリへ同期することを検証する。
+    /// </summary>
+    [Fact]
+    public async Task SyncModifiedFilesWithRepositoryAsyncはModified対象のみを同期する() {
+        var translateDir = Path.Combine( _tempDir, "Translate" );
+        const string modifiedPath = "DCSWorld/Mods/aircraft/A10C/L10N/Modified.lua";
+        const string localOnlyPath = "DCSWorld/Mods/aircraft/A10C/L10N/LocalOnly.lua";
+        const string repositoryContent = "repository-content";
+
+        var apiServiceMock = new Mock<IApiService>( MockBehavior.Strict );
+        var loggerMock = new Mock<ILoggingService>();
+        var applyWorkflowServiceMock = new Mock<IApplyWorkflowService>( MockBehavior.Strict );
+        var sut = new DownloadWorkflowService( apiServiceMock.Object, loggerMock.Object, applyWorkflowServiceMock.Object );
+
+        using var server = new TestHttpServer( repositoryContent );
+        apiServiceMock
+            .Setup( service => service.DownloadFilePathsAsync(
+                It.Is<ApiDownloadFilePathsRequest>( request =>
+                    request.Paths.Count == 1 &&
+                    request.Paths[0] == modifiedPath ),
+                It.IsAny<CancellationToken>() ) )
+            .ReturnsAsync( FluentResults.Result.Ok(
+                new ApiDownloadFilePathsResult(
+                    [new ApiDownloadFilePathsItem( server.Url, modifiedPath )],
+                    "\"etag\"" ) ) );
+
+        var result = await sut.SyncModifiedFilesWithRepositoryAsync(
+            [CreateModifiedEntry( modifiedPath ), CreateLocalOnlyEntry( localOnlyPath )],
+            translateDir,
+            _ => Task.CompletedTask,
+            TestContext.Current.CancellationToken );
+
+        Assert.True( result );
+        var modifiedFilePath = Path.Combine( translateDir, "DCSWorld", "Mods", "aircraft", "A10C", "L10N", "Modified.lua" );
+        Assert.True( File.Exists( modifiedFilePath ) );
+        Assert.Equal( repositoryContent, await File.ReadAllTextAsync( modifiedFilePath, TestContext.Current.CancellationToken ) );
+        var localOnlyFilePath = Path.Combine( translateDir, "DCSWorld", "Mods", "aircraft", "A10C", "L10N", "LocalOnly.lua" );
+        Assert.False( File.Exists( localOnlyFilePath ) );
+        apiServiceMock.VerifyAll();
+    }
+
+    /// <summary>
+    /// URL 取得失敗時に失敗を返すことを検証する。
+    /// </summary>
+    [Fact]
+    public async Task SyncModifiedFilesWithRepositoryAsyncはURL取得失敗時にfalseを返す() {
+        var translateDir = Path.Combine( _tempDir, "Translate" );
+        const string modifiedPath = "DCSWorld/Mods/aircraft/A10C/L10N/Modified.lua";
+
+        var apiServiceMock = new Mock<IApiService>( MockBehavior.Strict );
+        var loggerMock = new Mock<ILoggingService>();
+        var applyWorkflowServiceMock = new Mock<IApplyWorkflowService>( MockBehavior.Strict );
+        var sut = new DownloadWorkflowService( apiServiceMock.Object, loggerMock.Object, applyWorkflowServiceMock.Object );
+
+        apiServiceMock
+            .Setup( service => service.DownloadFilePathsAsync(
+                It.IsAny<ApiDownloadFilePathsRequest>(),
+                It.IsAny<CancellationToken>() ) )
+            .ReturnsAsync( FluentResults.Result.Fail<ApiDownloadFilePathsResult>( "failed" ) );
+
+        var messages = new List<string>();
+        var result = await sut.SyncModifiedFilesWithRepositoryAsync(
+            [CreateModifiedEntry( modifiedPath )],
+            translateDir,
+            message => {
+                messages.Add( message );
+                return Task.CompletedTask;
+            },
+            TestContext.Current.CancellationToken );
+
+        Assert.False( result );
+        Assert.Contains( messages, message => message.Contains( "ダウンロードURLの取得に失敗しました", StringComparison.Ordinal ) );
+        apiServiceMock.VerifyAll();
+    }
+
+    /// <summary>
+    /// 保存後に対象ファイルが存在しない場合に失敗を返すことを検証する。
+    /// </summary>
+    [Fact]
+    public async Task SyncModifiedFilesWithRepositoryAsyncは保存後に対象ファイルが存在しない場合falseを返す() {
+        var translateDir = Path.Combine( _tempDir, "Translate" );
+        const string modifiedPath = "DCSWorld/Mods/aircraft/A10C/L10N/Modified.lua";
+
+        var apiServiceMock = new Mock<IApiService>( MockBehavior.Strict );
+        var loggerMock = new Mock<ILoggingService>();
+        var applyWorkflowServiceMock = new Mock<IApplyWorkflowService>( MockBehavior.Strict );
+        var sut = new DownloadWorkflowService( apiServiceMock.Object, loggerMock.Object, applyWorkflowServiceMock.Object );
+
+        apiServiceMock
+            .Setup( service => service.DownloadFilePathsAsync(
+                It.IsAny<ApiDownloadFilePathsRequest>(),
+                It.IsAny<CancellationToken>() ) )
+            .ReturnsAsync( FluentResults.Result.Ok(
+                new ApiDownloadFilePathsResult(
+                    [],
+                    "\"etag\"" ) ) );
+
+        var result = await sut.SyncModifiedFilesWithRepositoryAsync(
+            [CreateModifiedEntry( modifiedPath )],
+            translateDir,
+            _ => Task.CompletedTask,
+            TestContext.Current.CancellationToken );
+
+        Assert.False( result );
+        apiServiceMock.VerifyAll();
+    }
+
+    /// <summary>
     /// 適用先解決ケースを返す。
     /// </summary>
     /// <returns>理論値一覧を返す。</returns>
@@ -442,6 +553,38 @@ public sealed class DownloadWorkflowServiceTests : IDisposable {
     }
 
     /// <summary>
+    /// Modified エントリーを生成する。
+    /// </summary>
+    /// <param name="entryPath">エントリーパス。</param>
+    /// <returns>生成したビューモデルを返す。</returns>
+    private static FileEntryViewModel CreateModifiedEntry( string entryPath ) {
+        var loggerMock = new Mock<ILoggingService>();
+        return new FileEntryViewModel(
+            new LocalFileEntry( Path.GetFileName( entryPath ), entryPath, false, "local" ) { RepoSha = "repo" },
+            ChangeTypeMode.Download,
+            loggerMock.Object )
+        {
+            CheckState = true
+        };
+    }
+
+    /// <summary>
+    /// LocalOnly エントリーを生成する。
+    /// </summary>
+    /// <param name="entryPath">エントリーパス。</param>
+    /// <returns>生成したビューモデルを返す。</returns>
+    private static FileEntryViewModel CreateLocalOnlyEntry( string entryPath ) {
+        var loggerMock = new Mock<ILoggingService>();
+        return new FileEntryViewModel(
+            new LocalFileEntry( Path.GetFileName( entryPath ), entryPath, false, "local" ),
+            ChangeTypeMode.Download,
+            loggerMock.Object )
+        {
+            CheckState = true
+        };
+    }
+
+    /// <summary>
     /// 選択中タブを生成する。
     /// </summary>
     /// <param name="categoryType">カテゴリ。</param>
@@ -481,6 +624,77 @@ public sealed class DownloadWorkflowServiceTests : IDisposable {
     /// <returns>区切り付きパスを返す。</returns>
     private static string EnsureSeparator( string path ) =>
         path.EndsWith( Path.DirectorySeparatorChar ) ? path : path + Path.DirectorySeparatorChar;
+
+    /// <summary>
+    /// テスト用HTTPサーバーを表す。
+    /// </summary>
+    private sealed class TestHttpServer : IDisposable {
+        private readonly HttpListener _listener = new();
+        private readonly CancellationTokenSource _cts = new();
+        private readonly Task _serverTask;
+
+        /// <summary>
+        /// 応答URLを取得する。
+        /// </summary>
+        public string Url { get; }
+            = $"http://127.0.0.1:{GetFreePort()}/content/";
+
+        /// <summary>
+        /// 新しいテスト用HTTPサーバーを初期化する。
+        /// </summary>
+        /// <param name="content">返却内容。</param>
+        public TestHttpServer( string content ) {
+            _listener.Prefixes.Add( Url );
+            _listener.Start();
+            _serverTask = Task.Run( async () => {
+                while(!_cts.IsCancellationRequested) {
+                    try {
+                        var context = await _listener.GetContextAsync();
+                        var buffer = Encoding.UTF8.GetBytes( content );
+                        context.Response.ContentType = "text/plain; charset=utf-8";
+                        context.Response.ContentLength64 = buffer.Length;
+                        await context.Response.OutputStream.WriteAsync( buffer, 0, buffer.Length, _cts.Token );
+                        context.Response.Close();
+                    }
+                    catch(HttpListenerException) when(_cts.IsCancellationRequested) {
+                        break;
+                    }
+                    catch(ObjectDisposedException) when(_cts.IsCancellationRequested) {
+                        break;
+                    }
+                }
+            }, _cts.Token );
+        }
+
+        /// <summary>
+        /// サーバーを破棄する。
+        /// </summary>
+        public void Dispose() {
+            _cts.Cancel();
+            if(_listener.IsListening) {
+                _listener.Stop();
+            }
+            _listener.Close();
+            try {
+                _serverTask.GetAwaiter().GetResult();
+            }
+            catch(OperationCanceledException) {
+            }
+            GC.SuppressFinalize( this );
+        }
+
+        /// <summary>
+        /// 空きポートを取得する。
+        /// </summary>
+        /// <returns>空きポート番号を返す。</returns>
+        private static int GetFreePort() {
+            var listener = new System.Net.Sockets.TcpListener( IPAddress.Loopback, 0 );
+            listener.Start();
+            var port = ((System.Net.IPEndPoint)listener.LocalEndpoint).Port;
+            listener.Stop();
+            return port;
+        }
+    }
 
     /// <summary>
     /// 使用した一時ディレクトリを破棄する。

--- a/tests/DcsTranslationTool.Presentation.Wpf.UnitTests/Services/DownloadWorkflowServiceTests.cs
+++ b/tests/DcsTranslationTool.Presentation.Wpf.UnitTests/Services/DownloadWorkflowServiceTests.cs
@@ -81,7 +81,7 @@ public sealed class DownloadWorkflowServiceTests : IDisposable {
     ) {
         var sut = CreateSut( out var applyWorkflowServiceMock, out var loggerMock );
         var targetEntry = CreateCheckedEntry( entryPath );
-        var selectedTab = CreateSelectedTab( categoryType, targetEntry, loggerMock.Object );
+        var selectedTab = CreateSelectedTab( categoryType, loggerMock.Object, targetEntry );
         var dcsWorldInstallDir = Path.Combine( _tempDir, "DcsWorld" );
         var translateDir = Path.Combine( _tempDir, "Translate" );
         var expectedRootPath = Path.Combine( _tempDir, expectedRootRelativePath );
@@ -139,7 +139,7 @@ public sealed class DownloadWorkflowServiceTests : IDisposable {
     ) {
         var sut = CreateSut( out var applyWorkflowServiceMock, out var loggerMock );
         var targetEntry = CreateCheckedEntry( entryPath );
-        var selectedTab = CreateSelectedTab( categoryType, targetEntry, loggerMock.Object );
+        var selectedTab = CreateSelectedTab( categoryType, loggerMock.Object, targetEntry );
         var dcsWorldInstallDir = Path.Combine( _tempDir, "DcsWorld" );
         var sourceArchivePath = Path.Combine( dcsWorldInstallDir, sourceArchiveRelativePath );
         Directory.CreateDirectory( Path.GetDirectoryName( sourceArchivePath )! );
@@ -203,7 +203,7 @@ public sealed class DownloadWorkflowServiceTests : IDisposable {
     ) {
         var sut = CreateSut( out var applyWorkflowServiceMock, out var loggerMock );
         var targetEntry = CreateCheckedEntry( entryPath );
-        var selectedTab = CreateSelectedTab( categoryType, targetEntry, loggerMock.Object );
+        var selectedTab = CreateSelectedTab( categoryType, loggerMock.Object, targetEntry );
         var dcsWorldInstallDir = Path.Combine( _tempDir, "DcsWorld" );
         var sourceArchivePath = Path.Combine( dcsWorldInstallDir, sourceArchiveRelativePath );
         Directory.CreateDirectory( Path.GetDirectoryName( sourceArchivePath )! );
@@ -253,7 +253,7 @@ public sealed class DownloadWorkflowServiceTests : IDisposable {
     public async Task ExecuteApplyAsyncは必要設定不足時に失敗を返す() {
         var sut = CreateSut( out var applyWorkflowServiceMock, out var loggerMock );
         var targetEntry = CreateCheckedEntry( "DCSWorld/Mods/aircraft/A10C/L10N/Example.lua" );
-        var selectedTab = CreateSelectedTab( CategoryType.Aircraft, targetEntry, loggerMock.Object );
+        var selectedTab = CreateSelectedTab( CategoryType.Aircraft, loggerMock.Object, targetEntry );
         var translateDir = Path.Combine( _tempDir, "Translate" );
         var request = new ApplyExecutionRequest(
             selectedTab,
@@ -326,6 +326,58 @@ public sealed class DownloadWorkflowServiceTests : IDisposable {
         Assert.Equal( repositoryContent, await File.ReadAllTextAsync( modifiedFilePath, TestContext.Current.CancellationToken ) );
         var localOnlyFilePath = Path.Combine( translateDir, "DCSWorld", "Mods", "aircraft", "A10C", "L10N", "LocalOnly.lua" );
         Assert.False( File.Exists( localOnlyFilePath ) );
+        apiServiceMock.VerifyAll();
+    }
+
+    /// <summary>
+    /// Download では LocalOnly を API リクエストから除外することを検証する。
+    /// </summary>
+    [Fact]
+    public async Task ExecuteDownloadAsyncはLocalOnlyを除外してダウンロードする() {
+        var saveRootPath = Path.Combine( _tempDir, "Translate" );
+        const string repoOnlyPath = "DCSWorld/Mods/aircraft/A10C/L10N/RepoOnly.lua";
+        const string modifiedPath = "DCSWorld/Mods/aircraft/A10C/L10N/Modified.lua";
+        const string localOnlyPath = "DCSWorld/Mods/aircraft/A10C/L10N/LocalOnly.lua";
+
+        var apiServiceMock = new Mock<IApiService>( MockBehavior.Strict );
+        var loggerMock = new Mock<ILoggingService>();
+        var applyWorkflowServiceMock = new Mock<IApplyWorkflowService>( MockBehavior.Strict );
+        var sut = new DownloadWorkflowService( apiServiceMock.Object, loggerMock.Object, applyWorkflowServiceMock.Object );
+
+        using var repoOnlyServer = new TestHttpServer( "repo-only-content" );
+        using var modifiedServer = new TestHttpServer( "modified-content" );
+        apiServiceMock
+            .Setup( service => service.DownloadFilePathsAsync(
+                It.Is<ApiDownloadFilePathsRequest>( request =>
+                    request.Paths.Count == 2 &&
+                    request.Paths.Contains( repoOnlyPath ) &&
+                    request.Paths.Contains( modifiedPath ) &&
+                    !request.Paths.Contains( localOnlyPath ) ),
+                It.IsAny<CancellationToken>() ) )
+            .ReturnsAsync( FluentResults.Result.Ok(
+                new ApiDownloadFilePathsResult(
+                    [
+                        new ApiDownloadFilePathsItem( repoOnlyServer.Url, repoOnlyPath ),
+                        new ApiDownloadFilePathsItem( modifiedServer.Url, modifiedPath )
+                    ],
+                    "\"etag\"" ) ) );
+
+        var selectedTab = CreateSelectedTab(
+            CategoryType.Aircraft,
+            loggerMock.Object,
+            CreateRepoOnlyEntry( repoOnlyPath ),
+            CreateModifiedEntry( modifiedPath ),
+            CreateLocalOnlyEntry( localOnlyPath ) );
+
+        var result = await sut.ExecuteDownloadAsync(
+            new DownloadExecutionRequest( selectedTab, saveRootPath ),
+            _ => Task.CompletedTask,
+            TestContext.Current.CancellationToken );
+
+        Assert.True( result.IsSuccess );
+        Assert.True( File.Exists( Path.Combine( saveRootPath, "DCSWorld", "Mods", "aircraft", "A10C", "L10N", "RepoOnly.lua" ) ) );
+        Assert.True( File.Exists( Path.Combine( saveRootPath, "DCSWorld", "Mods", "aircraft", "A10C", "L10N", "Modified.lua" ) ) );
+        Assert.False( File.Exists( Path.Combine( saveRootPath, "DCSWorld", "Mods", "aircraft", "A10C", "L10N", "LocalOnly.lua" ) ) );
         apiServiceMock.VerifyAll();
     }
 
@@ -569,6 +621,22 @@ public sealed class DownloadWorkflowServiceTests : IDisposable {
     }
 
     /// <summary>
+    /// RepoOnly エントリーを生成する。
+    /// </summary>
+    /// <param name="entryPath">エントリーパス。</param>
+    /// <returns>生成したビューモデルを返す。</returns>
+    private static FileEntryViewModel CreateRepoOnlyEntry( string entryPath ) {
+        var loggerMock = new Mock<ILoggingService>();
+        return new FileEntryViewModel(
+            new RepoFileEntry( Path.GetFileName( entryPath ), entryPath, false, "repo" ),
+            ChangeTypeMode.Download,
+            loggerMock.Object )
+        {
+            CheckState = true
+        };
+    }
+
+    /// <summary>
     /// LocalOnly エントリーを生成する。
     /// </summary>
     /// <param name="entryPath">エントリーパス。</param>
@@ -591,13 +659,13 @@ public sealed class DownloadWorkflowServiceTests : IDisposable {
     /// <param name="entry">対象エントリー。</param>
     /// <param name="logger">ロガー。</param>
     /// <returns>生成したタブを返す。</returns>
-    private static TabItemViewModel CreateSelectedTab( CategoryType categoryType, FileEntryViewModel entry, ILoggingService logger ) {
+    private static TabItemViewModel CreateSelectedTab( CategoryType categoryType, ILoggingService logger, params FileEntryViewModel[] entries ) {
         var root = new FileEntryViewModel(
             new LocalFileEntry( "root", "root", true, "local" ),
             ChangeTypeMode.Download,
             logger )
         {
-            Children = [entry]
+            Children = [.. entries]
         };
         return new TabItemViewModel( categoryType, logger, root );
     }

--- a/tests/DcsTranslationTool.Presentation.Wpf.UnitTests/UI/Dialogs/DownloadModifiedApplySelectionDialogTests.cs
+++ b/tests/DcsTranslationTool.Presentation.Wpf.UnitTests/UI/Dialogs/DownloadModifiedApplySelectionDialogTests.cs
@@ -1,0 +1,43 @@
+using DcsTranslationTool.Presentation.Wpf.UI.Dialogs.Parameters;
+using DcsTranslationTool.Presentation.Wpf.UI.Dialogs.Results;
+
+namespace DcsTranslationTool.Presentation.Wpf.UnitTests.UI.Dialogs;
+
+/// <summary>
+/// 差分個別選択ダイアログ関連型を検証する。
+/// </summary>
+public sealed class DownloadModifiedApplySelectionDialogTests {
+    /// <summary>
+    /// 選択項目の初期値がローカル版であることを検証する。
+    /// </summary>
+    [Fact]
+    public void 選択項目の初期値はローカル版である() {
+        var item = new DownloadModifiedApplySelectionItem( "DCSWorld/Mods/aircraft/A10C/L10N/Example.lua" );
+
+        Assert.Equal( DownloadModifiedApplySource.Local, item.ApplySource );
+        Assert.True( item.IsLocalSelected );
+        Assert.False( item.IsRepositorySelected );
+    }
+
+    /// <summary>
+    /// 結果生成時に選択状態を保持することを検証する。
+    /// </summary>
+    [Fact]
+    public void 結果生成時に選択状態を保持する() {
+        var repositoryItem = new DownloadModifiedApplySelectionItem( "DCSWorld/Mods/aircraft/A10C/L10N/Example.lua" )
+        {
+            ApplySource = DownloadModifiedApplySource.Repository
+        };
+        var localItem = new DownloadModifiedApplySelectionItem( "DCSWorld/Mods/aircraft/A10C/L10N/Alt.lua" );
+        var parameters = new DownloadModifiedApplySelectionDialogParameters
+        {
+            Items = [repositoryItem, localItem]
+        };
+
+        var result = parameters.CreateResult();
+
+        Assert.True( result.IsConfirmed );
+        Assert.Equal( DownloadModifiedApplySource.Repository, result.SelectedSources[repositoryItem.Path] );
+        Assert.Equal( DownloadModifiedApplySource.Local, result.SelectedSources[localItem.Path] );
+    }
+}


### PR DESCRIPTION
## 📌 概要

<!-- このPRの目的・背景を簡潔に書いてください -->
サーバーに存在するファイルしか適用できず、ローカルで作成したファイルを適用できなかった

## 🛠 変更内容

<!-- このPRで加えた変更をリストアップしてください -->
- LocalOnlyなファイルを適用できるようにした
- ローカルにファイルが存在する場合、サーバーからダウンロードするか確認するダイアログを追加した

## 留意点

<!-- このPRを使用するうえで注意すべきことをリストアップしてください。 -->
<!-- 必要がなければ N/A としてください -->
N/A

Closes #111 